### PR TITLE
app settings overwrites global settings

### DIFF
--- a/modeltrans/settings.py
+++ b/modeltrans/settings.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 DEBUG = getattr(settings, 'MODELTRANS_DEBUG', False)
 
-DEFAULT_LANGUAGE = 'en'
-ENABLE_REGISTRATIONS = True
+DEFAULT_LANGUAGE = settings.DEFAULT_LANGUAGE or 'en'
+ENABLE_REGISTRATIONS = settings.ENABLE_REGISTRATIONS or True
 
-AVAILABLE_LANGUAGES = ('nl', 'de', 'fr')
+AVAILABLE_LANGUAGES = settings.AVAILABLE_LANGUAGES or ('nl', 'de', 'fr')

--- a/modeltrans/settings.py
+++ b/modeltrans/settings.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 DEBUG = getattr(settings, 'MODELTRANS_DEBUG', False)
 
-DEFAULT_LANGUAGE = settings.DEFAULT_LANGUAGE or 'en'
-ENABLE_REGISTRATIONS = settings.ENABLE_REGISTRATIONS or True
+DEFAULT_LANGUAGE = getattr(settings, 'DEFAULT_LANGUAGE', 'en')
+ENABLE_REGISTRATIONS = getattr(settings, 'ENABLE_REGISTRATIONS', True)
 
-AVAILABLE_LANGUAGES = settings.AVAILABLE_LANGUAGES or ('nl', 'de', 'fr')
+AVAILABLE_LANGUAGES = getattr(settings, 'AVAILABLE_LANGUAGES', ('nl', 'de', 'fr'))


### PR DESCRIPTION
Hi jieter!  Excellent job you've done with your app! 👍  django-modeltranslation totally polluted my tables with extra fields :(
I had to use this little fix to make the app use my global settings, what you say?