### PR TITLE
Subquery alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Translates Django model fields in a `JSONField` using a registration approach.
 - [Available on pypi](https://pypi.python.org/pypi/django-modeltrans)
 - [Documentation](http://django-modeltrans.readthedocs.io/en/latest/)
 
+# Known issues
+
+Below is a list of things not yet implemented/catched into the
+Queryset/Manager and can be considered TODO.
+
+- If the field `'i18n'` is added to `.defer()`, augmentation will likely not work at all. Adding translated fields (`title_nl`) to `.defer()` will likely yield error messages, and doesn't make sense as they are stored in `i18n`.
+- Passing expressions (kwargs) containing references to translated fields in  `values()` and `values_list()` is not supported.
+- Using translated fields in `.annotate()`, `.distinct()`, `.extra()`, `.aggregate()`, `.update()` is not supported.
+- Behaveiour is tested using `CharField()` en `TextField()`, as these make most sense for translated values.
+
 # Running the tests
 
 `tox`

--- a/modeltrans/compat.py
+++ b/modeltrans/compat.py
@@ -2,9 +2,36 @@
 try:
     from django.contrib.postgres.fields.jsonb import KeyTextTransform
 except ImportError:
-    # django 1.11 implementation of KeyTextTransform for django 1.10 and 1.9
-    from django.contrib.postgres.fields.jsonb import KeyTransform
+    from django.contrib.postgres.fields.jsonb import Transform
     from django.db.models import TextField
+
+    # django 1.11 implementation of KeyTextTransform for django 1.10 and 1.9
+    # remove when support for django 1.9 and 1.0 is dropped
+
+    class KeyTransform(Transform):
+        operator = '->'
+        nested_operator = '#>'
+
+        def __init__(self, key_name, *args, **kwargs):
+            super(KeyTransform, self).__init__(*args, **kwargs)
+            self.key_name = key_name
+
+        def as_sql(self, compiler, connection):
+            key_transforms = [self.key_name]
+            previous = self.lhs
+            while isinstance(previous, KeyTransform):
+                key_transforms.insert(0, previous.key_name)
+                previous = previous.lhs
+            lhs, params = compiler.compile(previous)
+            if len(key_transforms) > 1:
+                return "(%s %s %%s)" % (lhs, self.nested_operator), [key_transforms] + params
+            try:
+                int(self.key_name)
+            except ValueError:
+                lookup = "'%s'" % self.key_name
+            else:
+                lookup = "%s" % self.key_name
+            return "(%s %s %s)" % (lhs, self.operator, lookup), params
 
     class KeyTextTransform(KeyTransform):
         operator = '->>'

--- a/modeltrans/compat.py
+++ b/modeltrans/compat.py
@@ -1,0 +1,12 @@
+
+try:
+    from django.contrib.postgres.fields.jsonb import KeyTextTransform
+except ImportError:
+    # django 1.11 implementation of KeyTextTransform for django 1.10 and 1.9
+    from django.contrib.postgres.fields.jsonb import KeyTransform
+    from django.db.models import TextField
+
+    class KeyTextTransform(KeyTransform):
+        operator = '->>'
+        nested_operator = '#>>'
+        _output_field = TextField()

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -172,13 +172,16 @@ class TranslatedVirtualField(object):
         return Field()
 
     def _localized_lookup(self, language):
+        from django.contrib.postgres.fields.jsonb import KeyTextTransform
+
         if language == DEFAULT_LANGUAGE:
             return self.original_name
 
         quoted_table_name = connection.ops.quote_name(self.model._meta.db_table)
         name = build_localized_fieldname(self.original_name, language)
-
-        return RawSQL('{}.i18n->>%s'.format(quoted_table_name), (name, ))
+        print quoted_table_name
+        return KeyTextTransform(name, 'i18n')
+        # return RawSQL('''{}."i18n" ->> %s '''.format(quoted_table_name), (name, ))
 
     def sql_lookup(self, fallback=True):
         '''

--- a/modeltrans/manager.py
+++ b/modeltrans/manager.py
@@ -217,7 +217,7 @@ class MultilingualQuerySet(models.query.QuerySet):
             return f
         field, _ = self._get_field(f.name)
 
-        rewritten = self.add_i18n_annotation(
+        rewritten = self._add_i18n_annotation(
             virtual_field=field,
             fallback=False,
             bare_lookup=f.name

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -24,6 +24,12 @@ class I18nMigrationTest(TestCase):
         self.assertTrue('app_category_i18n_gin' in output)
 
     def test_get_translatable_models(self):
+        '''
+        get_translatable_models() Should only work if django-modeltranslation is
+        available.
+        So if this test fails in your dev environment, you probably have
+        django-modeltranslation installed
+        '''
 
         with self.assertRaises(ImproperlyConfigured):
             get_translatable_models()

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -139,7 +139,6 @@ class FilterTest(TestCase):
             b = Blog.objects.get(Q(title_i18n='Kikker'))
             self.assertEquals(b.title, 'Frog')
 
-    @skip('temp')
     def test_filter_F_expression(self):
         Blog.objects.create(title='foo', title_nl=20, title_fr=10)
         Blog.objects.create(title='bar', title_nl=20, title_fr=30)
@@ -222,6 +221,11 @@ class OrderByTest(TestCase):
     def setUp(self):
         for i, en in enumerate(self.EN):
             Blog.objects.create(title=en, i18n={'title_nl': self.NL[i], 'title_fr': self.FR[i]})
+
+    def test_regular_fields(self):
+        qs = Blog.objects.all().order_by('-title')
+
+        self.assertEquals(key(qs, 'title'), 'G,F,E,D,C,B,A'.split(','))
 
     def test_order_by_two_fields(self):
         '''Multiple translated fields should work too'''


### PR DESCRIPTION
Make sure the table alias is used in subqueries, for example:

```
Blog.objects.filter(
    category__in=Category.objects.filter(name_nl__contains='an')
)
```

Fixes #23 and #13