### PR TITLE
WIP: trying pass expressions rather than annotating while filtering

### DIFF
--- a/modeltrans/manager.py
+++ b/modeltrans/manager.py
@@ -138,17 +138,13 @@ class MultilingualQuerySet(models.query.QuerySet):
         else:
             bare_lookup = lookup
 
-        filter_field_name = self._add_i18n_annotation(
-            virtual_field=field,
-            bare_lookup=bare_lookup,
-            fallback=field.language is None
-        )
+        expression = field.as_sql(fallback=field.language is None, bare_lookup=bare_lookup)
 
-        # re-add lookup type
         if lookup_type is not None:
-            filter_field_name += LOOKUP_SEP + lookup_type
+            for lookup in lookup_type.split(LOOKUP_SEP):
+                expression = field.get_lookup(lookup)(expression, value)
 
-        return filter_field_name, value
+        return expression
 
     def _rewrite_F(self, f):
         if not isinstance(f, models.F):
@@ -284,7 +280,11 @@ class MultilingualQuerySet(models.query.QuerySet):
         # handle the kwargs
         new_kwargs = {}
         for field, value in kwargs.items():
-            new_kwargs.update(dict((self._rewrite_expression(field, value), )))
+            expression = self._rewrite_expression(field, value)
+            if hasattr(expression, 'len'):
+                new_kwargs.update(dict((expression, )))
+            else:
+                new_args.append(expression)
 
         return super(MultilingualQuerySet, self)._filter_or_exclude(negate, *new_args, **new_kwargs)
 


### PR DESCRIPTION
Idea is to not create annotations while filtering. This cleans up the query, reduces distinct problems and prevents name collisions.

In the end, it should be possible to only annotate for `.values()` and `.values_list()`, to preserve the names in the lists/dicts returned.

https://docs.djangoproject.com/en/1.11/howto/custom-lookups/