### PR TITLE
ugettext changed to ugettext_lazy

### DIFF
--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -4,7 +4,7 @@ from django.contrib.postgres.fields.jsonb import JSONField, KeyTextTransform
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import fields
 from django.db.models.functions import Cast, Coalesce
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .conf import get_create_gin_setting, get_default_language, get_fallback_chain
 from .utils import build_localized_fieldname, get_i18n_index_name, get_language


### PR DESCRIPTION
This is fix at least for column heading in admin interface.
Otherwise (with just ugettext) the column heading is translated for the LANGUAGE_CODE from settings.py and isn't responsive to the current language (from browser settings or from /lang/ in url).

Without this fix column data in admin column will change for the required language, but the heading will not change.
