### PR TITLE
Fix exception on nullable i18n field

### DIFF
--- a/modeltrans/manager.py
+++ b/modeltrans/manager.py
@@ -26,7 +26,7 @@ def transform_translatable_fields(model, fields):
     if not hasattr(model, "i18n"):
         return fields
 
-    ret = {"i18n": fields.pop("i18n", {})}
+    ret = {"i18n": fields.pop("i18n", None) or {}}
 
     # keep track of translated fields, and do not return an `i18n` key if no
     # translated fields are found.

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -229,7 +229,7 @@ class FilterTest(TestCase):
         whale = Blog.objects.create(title="Blue Whale", title_nl="Blauwe vinvis")
 
         BlogAttr.objects.create(object=dog, attribute=mass, value=17)
-        BlogAttr.objects.create(object=dog, attribute=length, value=.50)
+        BlogAttr.objects.create(object=dog, attribute=length, value=0.50)
         BlogAttr.objects.create(object=whale, attribute=mass, value=181000)
         BlogAttr.objects.create(object=whale, attribute=length, value=28)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,20 @@ class UtilsTest(TestCase):
             {"i18n": {"title_nl": "foo"}, "title": "bar"},
         )
 
+    def test_transform_translatable_fields_without_translations(self):
+        self.assertEqual(
+            transform_translatable_fields(Blog, {"title": "bar", "title_nl": "foo", "i18n": None}),
+            {"i18n": {"title_nl": "foo"}, "title": "bar"},
+        )
+
+    def test_transform_translatable_fields_keep_translations(self):
+        self.assertEqual(
+            transform_translatable_fields(
+                Blog, {"title": "bar", "title_de": "das foo", "i18n": {"title_nl": "foo"}}
+            ),
+            {"i18n": {"title_nl": "foo", "title_de": "das foo"}, "title": "bar"},
+        )
+
     def test_build_localized_fieldname(self):
         self.assertEqual(build_localized_fieldname("title", "nl"), "title_nl")
         self.assertEqual(build_localized_fieldname("category__name", "nl"), "category__name_nl")


### PR DESCRIPTION
I caught this bug when i was playing with dumping and loading fixtures. The management command `dumpdata` generates `"i18n": null` for an object without translations, which raises an exception, because `ret["i18n"] is None`:

https://github.com/zostera/django-modeltrans/blob/b7528fae14c29ba8bb34bff9c15da7838f44e389/modeltrans/manager.py#L33