### PR TITLE
(UPDATE) prevent of using i18n field as form field

### DIFF
--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -52,6 +52,7 @@ class TranslatedVirtualField(object):
         self.null = kwargs["null"]
 
         self.concrete = False
+        self.editable = kwargs.pop("editable", True)
         self._help_text = kwargs.pop("help_text", None)
 
     @property

--- a/modeltrans/translator.py
+++ b/modeltrans/translator.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Manager
 
-from .conf import get_available_languages, get_default_language
+from .conf import get_available_languages
 from .fields import TranslationField, translated_field_factory
 from .manager import MultilingualManager, transform_translatable_fields
 
@@ -141,28 +141,17 @@ def add_virtual_fields(Model, fields, required_languages):
         raise_if_field_exists(Model, field.get_field_name())
         field.contribute_to_class(Model, field.get_field_name())
 
-        # add a virtual field pointing to the original field with name
-        # <original_field_name>_<LANGUAGE_CODE>
-        field = translated_field_factory(
-            original_field=original_field,
-            language=get_default_language(),
-            blank=True,
-            null=True,
-            editable=False,
-        )
-        raise_if_field_exists(Model, field.get_field_name())
-        field.contribute_to_class(Model, field.get_field_name())
-
         # now, for each language, add a virtual field to get the tranlation for
         # that specific langauge
         # <original_field_name>_<language>
-        for language in get_available_languages(include_default=False):
+        for language in get_available_languages():
             blank_allowed = language not in field_required_languages
             field = translated_field_factory(
                 original_field=original_field,
                 language=language,
                 blank=blank_allowed,
                 null=blank_allowed,
+                editable=original_field.editable,
             )
             raise_if_field_exists(Model, field.get_field_name())
             field.contribute_to_class(Model, field.get_field_name())

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,38 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.forms import ModelForm
+from django.core.exceptions import FieldError
+from django.forms import modelform_factory
 from django.test import TestCase
-from django.utils.translation import override
 
 from .app.models import Blog
 
 
 class ModelFormTest(TestCase):
-    def test_modelform(self):
-        class BlogForm(ModelForm):
-            class Meta:
-                model = Blog
-                fields = ("title_i18n", "body_i18n")
-
-        article = Blog(title="English", title_nl="Nederlands")
-
-        with override("nl"):
-            form = BlogForm(
-                instance=article, data={"title_i18n": "Nederlandse taal", "body_i18n": "foo"}
-            )
-            form.save()
-
-        article.refresh_from_db()
-        self.assertEqual(article.title_nl, "Nederlandse taal")
-        self.assertEqual(article.title_en, "English")
-
-        with override("en"):
-            form = BlogForm(
-                instance=article, data={"title_i18n": "English language", "body_i18n": "foo"}
-            )
-            form.save()
-
-        article.refresh_from_db()
-        self.assertEqual(article.title_nl, "Nederlandse taal")
-        self.assertEqual(article.title_en, "English language")
+    def test_i18n_virt_field_modelform(self):
+        with self.assertRaises(FieldError) as err:
+            modelform_factory(Blog, fields=("title_i18n",))
+        self.assertIn("'title_i18n' cannot be specified for Blog", str(err.exception))


### PR DESCRIPTION
Why i did it.
1. We have this line https://github.com/zostera/django-modeltrans/blob/master/modeltrans/translator.py#L138, currently flag (editable=False) did nothing because it isnt set to TranslatedVirtualField.
2. I think in case if we need active language model form we need to force user to use solution like ActiveLanguageMixin.
3. Also i18n virtual form field can be unpredictable in case of (required=False) because its always (blank | null = True).

Alternative of this solution can be using some kind of lazy form field.

What do you think?
