### PR TITLE
Add per-record fallback language feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       postgres:
         image: postgres:10.8
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: test1234
-          POSTGRES_DB: model-translation
+          POSTGRES_USER: modeltrans
+          POSTGRES_PASSWORD: modeltrans
+          POSTGRES_DB: modeltrans
         ports:
           - 5432:5432
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# django-modeltrans change log
+django-modeltrans change log
+============================
+
+## 0.5.0 (2020-11-23)
+ - Add per-record fallback feature #63
 
 ## 0.4.0 (2019-11-22)
  - Drop python 2, Django 1.11 and Django 2.0 support #56
@@ -66,9 +70,10 @@
 ## 0.0.7 (2017-09-04)
  - Cleaned up the settings used by django-modeltrans [#19](https://github.com/zostera/django-modeltrans/pull/19).
    This might be a breaking change, depending on your configuration.
-    * `AVAILABLE_LANGUAGES` is now renamed to `MODELTRANS_AVAILABLE_LANGUAGES` and defaults to the language codes in the
+
+   - `AVAILABLE_LANGUAGES` is now renamed to `MODELTRANS_AVAILABLE_LANGUAGES` and defaults to the language codes in the
       django `LANGUAGES` setting.
-    * `DEFAULT_LANGUAGE` is removed, instead, django-modeltrans uses the django `LANGUAGE_CODE` setting.
+   - `DEFAULT_LANGUAGE` is removed, instead, django-modeltrans uses the django `LANGUAGE_CODE` setting.
  - Added per-language configurable fallback using the `MODELTRANS_FALLBACK` setting.
 
 ## 0.0.6 (2017-08-29)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ notebook:
 	cd example && PYTHONPATH=.. ./manage.py shell_plus --notebook
 
 isort:
-	isort --recursive --diff --check modeltrans tests test_migrations example
+	isort --diff --check modeltrans tests test_migrations example
 
 .PHONY: test example

--- a/docs/pages/known-issues.rst
+++ b/docs/pages/known-issues.rst
@@ -15,7 +15,7 @@ Using translated fields in ``QuerySet``/``Manager`` methods
 
 Fields supported
 ----------------
-Behavior is tested using ``CharField()`` en ``TextField()``, as these make most sense for translated values.
+Behaviour is tested using ``CharField()`` en ``TextField()``, as these make most sense for translated values.
 Additional fields could make sense, and will likely work, but need extra test coverage.
 
 
@@ -30,7 +30,7 @@ Context of 'current language'
 Lookups (`<field>_i18n`) are translated when the line they are defined on is executed::
 
     class Foo():
-        qs = Blog.objects.filter(title_i18n__contains='foo')
+        qs = Blog.objects.filter(title_i18n__contains="foo")
 
         def get_blogs(self):
             return self.qs
@@ -41,3 +41,26 @@ But instead, the language active while creating the class ``Foo`` will be used.
 
 For example the `queryset` argument to `ModelChoiceField()`.
 See `github issue #34 <https://github.com/zostera/django-modeltrans/issues/34>`_
+
+Using translated fields from a related model
+--------------------------------------------
+``modeltrans.manager.MultilingualManager`` is required to transform `<field>_i18n` to the correct
+lookup in the ``JSONField``.
+
+If you want to use translated fields when building the query from a related model, you need to add
+``objects = MultilingualManager()`` to the model you want to build the query from.
+
+For example, ``Category`` needs ``objects = MultilingualManager()`` in order to allow
+``Category.objects.filter(blog__title_i18n__icontains="django")``::
+
+    class Category(models.Model):
+        title = models.CharField(max_length=255)
+
+        objects = MultilingualManager()  # required to use translated fields of Blog.
+
+    class Blog(models.Model):
+        title = models.CharField(max_length=255)
+        body = models.TextField(null=True)
+        category = models.ForeignKey(Category, null=True, blank=True, on_delete=models.CASCADE)
+
+        i18n = TranslationField(fields=("title", "body"))

--- a/docs/pages/known-issues.rst
+++ b/docs/pages/known-issues.rst
@@ -15,7 +15,7 @@ Using translated fields in ``QuerySet``/``Manager`` methods
 
 Fields supported
 ----------------
-Behaviour is tested using ``CharField()`` en ``TextField()``, as these make most sense for translated values.
+Behaviour is tested using ``CharField()`` and ``TextField()``, as these make most sense for translated values.
 Additional fields could make sense, and will likely work, but need extra test coverage.
 
 

--- a/docs/pages/settings.rst
+++ b/docs/pages/settings.rst
@@ -19,6 +19,8 @@ A custom definition might be::
     MODELTRANS_AVAILABLE_LANGUAGES = ('de', 'fr')
 
 
+.. _settings_fallback:
+
 ``MODELTRANS_FALLBACK``
 -----------------------
 A dict of fallback chains as lists of languages. By default, it falls back to the language defined in django setting `LANGUAGE_CODE`.
@@ -35,6 +37,18 @@ If configured like this::
        'default': (LANGUAGE_CODE, ),
        'fy': ('nl', 'en')
     }
+
+Note that a custom fallback language can be configured on a model instance if the `i18n` field is configured like this::
+
+    class Model(models.Model):
+        title = models.CharField(max_length=100)
+        fallback_language = models.CharField(max_length=2)
+
+        i18n = TranslationField(fields=("title",), fallback_language_field="fallback_language")
+
+in which ``fallback_language_field`` refers to the model field that contains the language code.
+
+This topic is explained in :ref:`custom_fallback`.
 
 
 ``MODELTRANS_ADD_FIELD_HELP_TEXT``

--- a/docs/pages/working-with-models.rst
+++ b/docs/pages/working-with-models.rst
@@ -6,10 +6,10 @@ Advanced usage
 Custom fallback language
 ------------------------
 
-By default, fallback is centrally configered with :ref:`settings_fallback`.
+By default, fallback is centrally configured with :ref:`settings_fallback`.
 That might not be sufficient, for example if part of the content is created for a single language which is not ``LANGUAGE_CODE``.
 
-In that case, it can be con configured per-record using the ``fallback_language_field`` argument to ``TranslationField``::
+In that case, it can be configured per-record using the ``fallback_language_field`` argument to ``TranslationField``::
 
     class NewsRoom(models.Model):
         name = models.CharField(max_length=255)
@@ -39,10 +39,10 @@ With the models above::
     )
 
     with override('de'):
-        # language 'de' not available, will fallback to the records default_language
+        # If language 'de' is not available, the records default_language will be used.
         print(nos.name)  # 'NOS (nl)'
 
-        # language 'de' not available, will fallback to the newsroom.default_language
+        #  If language 'de' is not available, the newsroom.default_language will be used.
         print(article.content)  # 'VS-Europeese oceaanbewakingssatelliet gelanceerd'
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==1.6.5
 Django
 sphinx_rtd_theme
 recommonmark
-psycopg2
+psycopg2-binary==2.8.6
 
 sphinxcontrib-spelling
 pyenchant

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -282,8 +282,8 @@ class TranslationField(JSONField):
         fallback_language_field: If not None, this should be the name of the field containing a
             language code to use as the first language in any fallback chain.
             For example: if you have a model instance with 'nl' as language_code, and set
-            fallback_language_field='language_code', nl will always be tried before any other language.
-
+            fallback_language_field='language_code', 'nl' will always be tried after the current
+            language before any other language.
     """
 
     description = "Translation storage for a model"

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -103,7 +103,7 @@ class TranslatedVirtualField:
             )
 
             if record_fallback_language:
-                return [record_fallback_language] + [default]
+                return [record_fallback_language, *default]
 
         return default
 

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -88,6 +88,12 @@ class TranslatedVirtualField:
         return None
 
     def get_instance_fallback_chain(self, instance, language):
+        """
+        Return the fallback chain for the instance.
+
+        Most of the time, it is just the configured fallback chain, but if the per-record-fallback feature
+        is used, the value of the field is added (if not None).
+        """
         default = get_fallback_chain(language)
 
         i18n_field = instance._meta.get_field("i18n")
@@ -95,6 +101,7 @@ class TranslatedVirtualField:
             record_fallback_language = get_instance_field_value(
                 instance, i18n_field.fallback_language_field
             )
+
             if record_fallback_language:
                 return [record_fallback_language] + [default]
 
@@ -226,10 +233,10 @@ class TranslatedVirtualField:
             return Cast(i18n_lookup, self.output_field())
 
         fallback_chain = get_fallback_chain(language)
-        # first, add the current language to the list of lookups
+        # First, add the current language to the list of lookups
         lookups = [self._localized_lookup(language, bare_lookup)]
 
-        # optionnally add the lookup for the per-row fallback language
+        # Optionnally add the lookup for the per-row fallback language
         i18n_field = self.model._meta.get_field("i18n")
         if i18n_field.fallback_language_field:
             lookups.append(

--- a/modeltrans/manager.py
+++ b/modeltrans/manager.py
@@ -79,13 +79,12 @@ class MultilingualQuerySet(QuerySet):
         version of a field from the jsonb field to allow filtering and ordering.
 
         Arguments:
-            field (TranslatedVirtualField): the virtual field to create an annotation for.
+            virtual_field (TranslatedVirtualField): the virtual field to create an annotation for.
+            fallback (bool): If `True`, `COALESCE` will be used to get the value of the original
+                field if the requested translation is not in the `i18n` dict.
+            bare_lookup:
             annotation_name (str): name of the annotation, if None the default
-                `<original_field>_<lang>_annotation` will be used
-
-            fallback (bool): If `True`, `COALESCE` will be used to get the value
-                of the original field if the requested translation is not in the
-                `i18n` dict.
+                `<original_field>_<lang>_annotation` will be used.
 
         Returns:
             the name of the annotation created.
@@ -135,11 +134,12 @@ class MultilingualQuerySet(QuerySet):
 
     def _rewrite_filter_clause(self, lookup, value):
         """
-        private method which rewrites a filter clause passed to filter()/exclude()
-        etc., for example:
+        Rewrite a filter clause passed to filter()/exclude()/etc.
+
+        for example:
 
         for title_nl__like='va'
-        _rewrite_filter_clause('title_nl__like', 'va') would be called.
+        _rewrite_filter_clause('title_nl__like', 'va') should be called.
         """
         value = self._rewrite_expression(value)
         field, lookup_type = self._get_field(lookup)
@@ -166,7 +166,7 @@ class MultilingualQuerySet(QuerySet):
         """
         Rewrite expressions.
 
-        https://docs.djangoproject.com/en/2.0/ref/models/expressions/
+        https://docs.djangoproject.com/en/stable/ref/models/expressions/
 
         This current way of doing this is bound to lag behind any new things implemented in Django.
         It would be really nice to have a better/more generic way of doing this.

--- a/modeltrans/manager.py
+++ b/modeltrans/manager.py
@@ -64,7 +64,7 @@ class MultilingualQuerySet(QuerySet):
 
      - `<field>` allow getting/setting the default language
      - ``<field>_<lang>`` (for example, `<field>_de`) allows getting/setting a specific language.
-       Note that if `LANGUAGE_CODE == 'en'`, `<field>_en` is mapped to `<field>`.
+       Note that if `LANGUAGE_CODE == "en"`, `<field>_en` is mapped to `<field>`.
      - `<field>_i18n` follows the currently active translation in Django, and falls back to the default language.
 
     When adding the `modeltrans.fields.TranslationField` to a model, MultilingualManager is automatically
@@ -138,8 +138,8 @@ class MultilingualQuerySet(QuerySet):
 
         for example:
 
-        for title_nl__like='va'
-        _rewrite_filter_clause('title_nl__like', 'va') should be called.
+        for title_nl__like="va"
+        _rewrite_filter_clause("title_nl__like", "va") should be called.
         """
         value = self._rewrite_expression(value)
         field, lookup_type = self._get_field(lookup)
@@ -249,7 +249,7 @@ class MultilingualQuerySet(QuerySet):
     def create(self, **kwargs):
         """
         Patch the create method to allow adding the value for a translated field
-        using `Model.objects.create(..., title_nl='...')`.
+        using `Model.objects.create(..., title_nl="...")`.
 
         https://docs.djangoproject.com/en/stable/ref/models/querysets/#create
         """
@@ -278,11 +278,11 @@ class MultilingualQuerySet(QuerySet):
         Annotate lookups for `filter()` and `exclude()`.
 
         Examples:
-            - `title_nl__contains='foo'` will add an annotation for `title_nl`
-            - `title_nl='bar'` will add an annotation for `title_nl`
-            - `title_i18n='foo'` will add an annotation for a coalesce of the
+            - `title_nl__contains="foo"` will add an annotation for `title_nl`
+            - `title_nl="bar"` will add an annotation for `title_nl`
+            - `title_i18n="foo"` will add an annotation for a coalesce of the
                current active language, and all items of the fallback chain.
-            - `Q(title_nl__contains='foo') will add an annotation for `title_nl`
+            - `Q(title_nl__contains="foo") will add an annotation for `title_nl`
 
         In all cases, the field part of the field lookup will be changed to use
         the annotated verion.
@@ -304,10 +304,10 @@ class MultilingualQuerySet(QuerySet):
         Annotate lookups for `values()` and `values_list()`
 
         It must be possible to use:
-        `Blogs.objects.all().values_list('title_i18n', 'title_nl', 'title_en')`
+        `Blogs.objects.all().values_list("title_i18n", "title_nl", "title_en")`
 
         But also spanning relations:
-        `Blogs.objects.all().values_list('title_i18n', 'category__name__i18n')`
+        `Blogs.objects.all().values_list("title_i18n", "category__name__i18n")`
         """
         _fields = fields + tuple(expressions)
 
@@ -360,7 +360,7 @@ class MultilingualManager(Manager):
     ``objects = MultilingualManager()`` to the model you want to build the query from.
 
     For example, ``Category`` needs ``objects = MultilingualManager()`` in order to allow
-    ``Category.objects.filter(blog__title_i18n__icontains='django')``::
+    ``Category.objects.filter(blog__title_i18n__icontains="django")``::
 
         class Category(models.Model):
             title = models.CharField(max_length=255)

--- a/modeltrans/translator.py
+++ b/modeltrans/translator.py
@@ -5,6 +5,7 @@ from django.db.models import Manager
 from .conf import get_available_languages, get_default_language
 from .fields import TranslationField, translated_field_factory
 from .manager import MultilingualManager, transform_translatable_fields
+from .utils import get_model_field
 
 
 def get_i18n_field(Model):
@@ -92,9 +93,8 @@ def validate(Model):
             )
 
     if i18n_field.fallback_language_field:
-        try:
-            Model._meta.get_field(i18n_field.fallback_language_field)
-        except FieldDoesNotExist:
+        field = get_model_field(Model, i18n_field.fallback_language_field)
+        if field is None:
             raise ImproperlyConfigured(
                 'Argument "fallback_language_field" to TranslationField is "{}", '
                 "which is not an existing field.".format(i18n_field.fallback_language_field)

--- a/modeltrans/translator.py
+++ b/modeltrans/translator.py
@@ -91,6 +91,15 @@ def validate(Model):
                 "which is not a field (missing a comma?).".format(field)
             )
 
+    if i18n_field.fallback_language_field:
+        try:
+            Model._meta.get_field(i18n_field.fallback_language_field)
+        except FieldDoesNotExist:
+            raise ImproperlyConfigured(
+                'Argument "fallback_language_field" to TranslationField is "{}", '
+                "which is not an existing field.".format(i18n_field.fallback_language_field)
+            )
+
     if i18n_field.required_languages:
         required_languages = i18n_field.required_languages
         allowed_types = (tuple, list, set)

--- a/modeltrans/utils.py
+++ b/modeltrans/utils.py
@@ -1,3 +1,5 @@
+from django.contrib.postgres.fields.jsonb import KeyTransform
+from django.db.models.lookups import Transform
 from django.utils.translation import get_language as _get_language
 
 from .conf import get_available_languages, get_default_language
@@ -26,3 +28,39 @@ def build_localized_fieldname(field_name, lang):
         # current naming scheme as Django foreign keys also add "id" suffix.
         lang = "ind"
     return "{}_{}".format(field_name, lang.replace("-", "_"))
+
+
+class FallbackTransform(Transform):
+    """
+    Custom version of KeyTextTransform to use a database field as part of the key.
+
+    For example: with default_language="nl", calling
+    `FallbackTransformb("title_", F("fallback_language"), "i18n")` becomes in SQL"
+        `"i18n"->>('title_' || "fallback_language")`
+    """
+
+    def __init__(self, field_prefix, language_expression, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.field_prefix = field_prefix
+        self.language_expression = language_expression
+
+    def preprocess_lhs(self, compiler, connection, lhs_only=False):
+        if not lhs_only:
+            key_transforms = [self.field_prefix]
+        previous = self.lhs
+        while isinstance(previous, KeyTransform):
+            if not lhs_only:
+                key_transforms.insert(0, previous.key_name)
+            previous = previous.lhs
+        lhs, params = compiler.compile(previous)
+        return (lhs, params, key_transforms) if not lhs_only else (lhs, params)
+
+    def as_postgresql(self, compiler, connection):
+        lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
+        params.extend([self.field_prefix])
+
+        rhs = self.language_expression.resolve_expression(compiler.query)
+        rhs_sql, rhs_params = compiler.compile(rhs)
+        params.extend(rhs_params)
+
+        return "(%s ->> (%%s || %s ))" % (lhs, rhs_sql), (params)

--- a/modeltrans/utils.py
+++ b/modeltrans/utils.py
@@ -25,4 +25,4 @@ def build_localized_fieldname(field_name, lang):
         # The 2-letter Indonesian language code is problematic with the
         # current naming scheme as Django foreign keys also add "id" suffix.
         lang = "ind"
-    return str("{}_{}".format(field_name, lang.replace("-", "_")))
+    return "{}_{}".format(field_name, lang.replace("-", "_"))

--- a/test_migrations/migrate_test/settings.py
+++ b/test_migrations/migrate_test/settings.py
@@ -120,7 +120,7 @@ STATIC_URL = "/static/"
 if "test" in sys.argv:
     print("\n\033[33mWarning\033[00m: Running without migrations")
 
-    class DisableMigrations(object):
+    class DisableMigrations:
         def __contains__(self, item):
             return True
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -175,3 +175,6 @@ class CustomFallbackLanguage(models.Model):
     default_language = models.CharField(max_length=2, default=settings.LANGUAGE_CODE)
 
     i18n = TranslationField(fields=("title",), fallback_language_field="default_language")
+
+    def __str__(self):
+        return self.title_i18n

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -164,3 +165,13 @@ class ChildArticle(Article):
 
     child_title = models.CharField(max_length=255)
     i18n_field_params = {"fields": ["title", "child_title"], "required_languages": ("nl",)}
+
+
+class CustomFallbackLanguage(models.Model):
+    """Model using a custom fallback language per instance/record."""
+
+    title = models.CharField(max_length=255)
+
+    default_language = models.CharField(max_length=2, default=settings.LANGUAGE_CODE)
+
+    i18n = TranslationField(fields=("title",), fallback_language_field="default_language")

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -172,7 +171,7 @@ class CustomFallbackLanguage(models.Model):
 
     title = models.CharField(max_length=255)
 
-    default_language = models.CharField(max_length=2, default=settings.LANGUAGE_CODE)
+    default_language = models.CharField(max_length=2, null=True, blank=True)
 
     i18n = TranslationField(fields=("title",), fallback_language_field="default_language")
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -166,7 +166,7 @@ class ChildArticle(Article):
     i18n_field_params = {"fields": ["title", "child_title"], "required_languages": ("nl",)}
 
 
-class CustomFallbackLanguage(models.Model):
+class Challenge(models.Model):
     """Model using a custom fallback language per instance/record."""
 
     title = models.CharField(max_length=255)
@@ -177,3 +177,15 @@ class CustomFallbackLanguage(models.Model):
 
     def __str__(self):
         return self.title_i18n
+
+
+class ChallengeContent(models.Model):
+    challenge = models.ForeignKey(Challenge, on_delete=models.CASCADE)
+    content = models.TextField()
+
+    i18n = TranslationField(
+        fields=("content",), fallback_language_field="challenge__default_language"
+    )
+
+    def __str__(self):
+        return self.content_i18n

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -180,6 +180,8 @@ class Challenge(models.Model):
 
 
 class ChallengeContent(models.Model):
+    """Model using a custom fallback language on a related record."""
+
     challenge = models.ForeignKey(Challenge, on_delete=models.CASCADE)
     content = models.TextField()
 

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -77,9 +77,9 @@ WSGI_APPLICATION = "example.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": "model-translation",
-        "USER": "postgres",
-        "PASSWORD": "test1234",
+        "NAME": "modeltrans",
+        "USER": "modeltrans",
+        "PASSWORD": "modeltrans",
         "HOST": "localhost",
         "PORT": 5432,
         "CONN_MAX_AGE": 600,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -285,6 +285,14 @@ class CustomFallbackLanguageTest(TestCase):
         with override("nl"):
             self.assertEqual(instance.title_i18n, "Hoera")
 
+    def test_empty_original_field(self):
+        instance = Challenge(default_language="nl", title="", i18n={"title_nl": "Hoera"})
+
+        with override("de"):
+            self.assertEqual(instance.title_i18n, "Hoera")
+        with override("en"):
+            self.assertEqual(instance.title_i18n, "Hoera")
+
     def test_instance_fallback_follow_relation(self):
         challenge = Challenge.objects.create(default_language="nl", title="Hurray")
         content = ChallengeContent(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,9 @@ from modeltrans.fields import TranslationField
 from .app.models import (
     Article,
     Blog,
+    Challenge,
+    ChallengeContent,
     ChildArticle,
-    CustomFallbackLanguage,
     NullableTextModel,
     TextModel,
 )
@@ -275,9 +276,7 @@ class TranslatedFieldTest(TestCase):
 class CustomFallbackLanguageTest(TestCase):
     def test_instance_fallback(self):
 
-        instance = CustomFallbackLanguage(
-            default_language="nl", title="Hurray", i18n={"title_nl": "Hoera"}
-        )
+        instance = Challenge(default_language="nl", title="Hurray", i18n={"title_nl": "Hoera"})
 
         with override("de"):
             self.assertEqual(instance.title_i18n, "Hoera")
@@ -285,6 +284,19 @@ class CustomFallbackLanguageTest(TestCase):
             self.assertEqual(instance.title_i18n, "Hurray")
         with override("nl"):
             self.assertEqual(instance.title_i18n, "Hoera")
+
+    def test_instance_fallback_follow_relation(self):
+        challenge = Challenge.objects.create(default_language="nl", title="Hurray")
+        content = ChallengeContent(
+            challenge=challenge, content="Congratulations", i18n={"content_nl": "Gefeliciteerd"}
+        )
+
+        with override("de"):
+            self.assertEqual(content.content_i18n, "Gefeliciteerd")
+        with override("en"):
+            self.assertEqual(content.content_i18n, "Congratulations")
+        with override("nl"):
+            self.assertEqual(content.content_i18n, "Gefeliciteerd")
 
 
 class TranslatedFieldInheritanceTest(TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -298,6 +298,18 @@ class CustomFallbackLanguageTest(TestCase):
         with override("nl"):
             self.assertEqual(content.content_i18n, "Gefeliciteerd")
 
+    def test_instance_fallback_without_related_instance(self):
+        content = ChallengeContent(content="Congratulations", i18n={"content_nl": "Gefeliciteerd"})
+        self.assertEqual(content.content_nl, "Gefeliciteerd")
+        self.assertEqual(content.content_en, "Congratulations")
+
+        with override("de"):
+            self.assertEqual(content.content_i18n, "Congratulations")
+        with override("en"):
+            self.assertEqual(content.content_i18n, "Congratulations")
+        with override("nl"):
+            self.assertEqual(content.content_i18n, "Gefeliciteerd")
+
 
 class TranslatedFieldInheritanceTest(TestCase):
     def test_child_model_i18n_fields(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,9 +10,9 @@ from .app.models import (
     Article,
     Blog,
     ChildArticle,
+    CustomFallbackLanguage,
     NullableTextModel,
     TextModel,
-    CustomFallbackLanguage,
 )
 from .utils import CreateTestModel
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,14 @@ from django.utils.translation import override
 
 from modeltrans.fields import TranslationField
 
-from .app.models import Article, Blog, ChildArticle, NullableTextModel, TextModel
+from .app.models import (
+    Article,
+    Blog,
+    ChildArticle,
+    NullableTextModel,
+    TextModel,
+    CustomFallbackLanguage,
+)
 from .utils import CreateTestModel
 
 
@@ -263,6 +270,21 @@ class TranslatedFieldTest(TestCase):
 
         with self.assertRaises(ValueError):
             blog.title_i18n
+
+
+class CustomFallbackLanguageTest(TestCase):
+    def test_instance_fallback(self):
+
+        instance = CustomFallbackLanguage(
+            default_language="nl", title="Hurray", i18n={"title_nl": "Hoera"}
+        )
+
+        with override("de"):
+            self.assertEqual(instance.title_i18n, "Hoera")
+        with override("en"):
+            self.assertEqual(instance.title_i18n, "Hurray")
+        with override("nl"):
+            self.assertEqual(instance.title_i18n, "Hoera")
 
 
 class TranslatedFieldInheritanceTest(TestCase):

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -291,7 +291,7 @@ class FilterTest(TestCase):
         self.assertEqual({m.name for m in qs}, {"Modeltrans blog"})
 
 
-class CustomFallbackLanguageTest(TestCase):
+class CustomFallbackTest(TestCase):
     def test_custom_fallback(self):
         instance = CustomFallbackLanguage.objects.create(
             default_language="nl", title="Hurray", i18n={"title_nl": "Hoera"}
@@ -300,7 +300,21 @@ class CustomFallbackLanguageTest(TestCase):
         with override("de"):
             qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
             self.assertCountEqual(qs, [instance])
+        with override("nl"):
+            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
+            self.assertCountEqual(qs, [instance])
+        with override("en"):
+            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
+            self.assertCountEqual(qs, [])
 
+    def test_custom_fallback_null(self):
+        instance = CustomFallbackLanguage.objects.create(
+            default_language=None, title="Hurray", i18n={"title_nl": "Hoera"}
+        )
+        with override("de"):
+            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
+            print(qs.query)
+            self.assertCountEqual(qs, [])
         with override("nl"):
             qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
             self.assertCountEqual(qs, [instance])

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -10,7 +10,7 @@ from django.utils.translation import override
 from modeltrans.fields import TranslationField
 from modeltrans.translator import translate_model
 
-from .app.models import Attribute, Blog, BlogAttr, Category, CustomFallbackLanguage, Site
+from .app.models import Attribute, Blog, BlogAttr, Category, Challenge, ChallengeContent, Site
 from .utils import CreateTestModel, load_wiki
 
 
@@ -293,33 +293,43 @@ class FilterTest(TestCase):
 
 class CustomFallbackTest(TestCase):
     def test_custom_fallback(self):
-        instance = CustomFallbackLanguage.objects.create(
+        instance = Challenge.objects.create(
             default_language="nl", title="Hurray", i18n={"title_nl": "Hoera"}
         )
 
         with override("de"):
-            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            self.assertCountEqual(qs, [instance])
+            self.assertCountEqual(Challenge.objects.filter(title_i18n="Hoera"), [instance])
         with override("nl"):
-            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            self.assertCountEqual(qs, [instance])
+            self.assertCountEqual(Challenge.objects.filter(title_i18n="Hoera"), [instance])
         with override("en"):
-            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            self.assertCountEqual(qs, [])
+            self.assertCountEqual(Challenge.objects.filter(title_i18n="Hoera"), [])
 
     def test_custom_fallback_null(self):
-        instance = CustomFallbackLanguage.objects.create(
+        instance = Challenge.objects.create(
             default_language=None, title="Hurray", i18n={"title_nl": "Hoera"}
         )
         with override("de"):
-            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            self.assertCountEqual(qs, [])
+            self.assertCountEqual(Challenge.objects.filter(title_i18n="Hoera"), [])
         with override("nl"):
-            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            self.assertCountEqual(qs, [instance])
+            self.assertCountEqual(Challenge.objects.filter(title_i18n="Hoera"), [instance])
         with override("en"):
-            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            self.assertCountEqual(qs, [])
+            self.assertCountEqual(Challenge.objects.filter(title_i18n="Hoera"), [])
+
+    def test_custom_fallback_follow_relation(self):
+        challenge = Challenge.objects.create(default_language="nl", title="Hurray")
+        content = ChallengeContent.objects.create(
+            challenge=challenge, content="Congratulations", i18n={"content_nl": "Gefeliciteerd"}
+        )
+        with override("de"):
+            self.assertCountEqual(
+                ChallengeContent.objects.filter(content_i18n="Gefeliciteerd"), [content]
+            )
+        with override("nl"):
+            self.assertCountEqual(
+                ChallengeContent.objects.filter(content_i18n="Gefeliciteerd"), [content]
+            )
+        with override("en"):
+            self.assertCountEqual(ChallengeContent.objects.filter(content_i18n="Gefeliciteerd"), [])
 
 
 class FulltextSearch(TestCase):

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -10,7 +10,7 @@ from django.utils.translation import override
 from modeltrans.fields import TranslationField
 from modeltrans.translator import translate_model
 
-from .app.models import Attribute, Blog, BlogAttr, Category, Site
+from .app.models import Attribute, Blog, BlogAttr, Category, CustomFallbackLanguage, Site
 from .utils import CreateTestModel, load_wiki
 
 
@@ -289,6 +289,24 @@ class FilterTest(TestCase):
 
         qs = Site.objects.filter(blog__title_i18n__contains="modeltrans")
         self.assertEqual({m.name for m in qs}, {"Modeltrans blog"})
+
+
+class CustomFallbackLanguageTest(TestCase):
+    def test_custom_fallback(self):
+        instance = CustomFallbackLanguage.objects.create(
+            default_language="nl", title="Hurray", i18n={"title_nl": "Hoera"}
+        )
+
+        with override("de"):
+            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
+            self.assertCountEqual(qs, [instance])
+
+        with override("nl"):
+            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
+            self.assertCountEqual(qs, [instance])
+        with override("en"):
+            qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
+            self.assertCountEqual(qs, [])
 
 
 class FulltextSearch(TestCase):

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -313,7 +313,6 @@ class CustomFallbackTest(TestCase):
         )
         with override("de"):
             qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")
-            print(qs.query)
             self.assertCountEqual(qs, [])
         with override("nl"):
             qs = CustomFallbackLanguage.objects.filter(title_i18n="Hoera")

--- a/tests/test_translating.py
+++ b/tests/test_translating.py
@@ -42,7 +42,8 @@ class Translating_utils(TestCase):
             app_models.NullableTextModel,
             app_models.Attribute,
             app_models.Choice,
-            app_models.CustomFallbackLanguage,
+            app_models.Challenge,
+            app_models.ChallengeContent,
         }
         self.assertEqual(set(get_translated_models("app")), expected)
 

--- a/tests/test_translating.py
+++ b/tests/test_translating.py
@@ -42,6 +42,7 @@ class Translating_utils(TestCase):
             app_models.NullableTextModel,
             app_models.Attribute,
             app_models.Choice,
+            app_models.CustomFallbackLanguage,
         }
         self.assertEqual(set(get_translated_models("app")), expected)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,15 @@ from django.test import TestCase
 from django.utils.translation import override
 
 from modeltrans.manager import transform_translatable_fields
-from modeltrans.utils import build_localized_fieldname, get_language, split_translated_fieldname
+from modeltrans.utils import (
+    build_localized_fieldname,
+    get_instance_field_value,
+    get_language,
+    get_model_field,
+    split_translated_fieldname,
+)
 
-from .app.models import Blog
+from .app.models import Blog, Category
 
 
 class UtilsTest(TestCase):
@@ -47,3 +53,20 @@ class UtilsTest(TestCase):
         self.assertEqual(build_localized_fieldname("category__name", "nl"), "category__name_nl")
         self.assertEqual(build_localized_fieldname("title", "id"), "title_ind")
         self.assertEqual(build_localized_fieldname("title", "en-US"), "title_en_US")
+
+    def test_get_model_field(self):
+        with self.assertRaises(ValueError):
+            get_model_field(object(), "name")
+        self.assertEqual(get_model_field(Category, "name"), Category._meta.get_field("name"))
+        self.assertEqual(get_model_field(Category, "color"), None)
+        self.assertEqual(get_model_field(Blog, "category__name"), Category._meta.get_field("name"))
+        self.assertEqual(get_model_field(Blog, "category__color"), None)
+
+    def test_get_instance_field_value(self):
+        test = Category(name="test")
+        blog = Blog(category=test, title="Python")
+
+        self.assertEqual(get_instance_field_value(Category(), "content"), None)
+        self.assertEqual(get_instance_field_value(test, "name"), "test")
+        self.assertEqual(get_instance_field_value(blog, "category__name"), "test")
+        self.assertEqual(get_instance_field_value(blog, "category__color"), None)


### PR DESCRIPTION
This allows a per-record fallback language to take precedence over `settings.LANGUAGE_CODE`.

```python
class Blog(models.Model):
    """Model using a custom fallback language per instance/record."""

    title = models.CharField(max_length=255)
    content = models.TextField()

    default_language = models.CharField(max_length=2, null=True, blank=True)

    i18n = TranslationField(fields=("title", "content"), fallback_language_field="default_language")

    def __str__(self):
        return self.title_i18n
```

With `settings.LANGUAGE_CODE = "en"`

```python
blog_nl = Blog.objects.create(default_language="nl", title="My blog", title_nl="Mijn blog")
blog = Blog.objects.create(title="My blog", title_nl="Mijn blog")

with override("de"):
    blog_nl.title_i18n  # Mijn blog
    blog.title_i18n. # My blog
```
