### PR TITLE
Adjust imports to remove deprecation warnings with django==3.1.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Translates Django model fields in a `JSONField` using a registration approach.
 
 # Features/requirements
 
-- Uses one PostgreSQL jsonb field `django.contrib.postgres.JSONField` (Django <3.1) 
-  or `django.db.models.JSONField` (Django 3.1) per model.
+- Uses one PostgreSQL `jsonb`-field per model.
+  (`django.contrib.postgres.JSONField` for Django<3.1, `django.db.models.JSONField` for Django>=3.1)
 - Django 2.2, 3.0, 3.1 (with their supported python versions)
 - PostgreSQL >= 9.5 and Psycopg2 >= 2.5.4.
 - [Available on pypi](https://pypi.python.org/pypi/django-modeltrans)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Translates Django model fields in a `JSONField` using a registration approach.
 
 # Features/requirements
 
-- Uses one `django.contrib.postgres.JSONField` (PostgreSQL jsonb field) per model.
-- Django 2.2, 3.0 (with their supported python versions)
+- Uses one PostgreSQL jsonb field `django.contrib.postgres.JSONField` (Django <3.1) 
+  or `django.db.models.JSONField` (Django 3.1) per model.
+- Django 2.2, 3.0, 3.1 (with their supported python versions)
 - PostgreSQL >= 9.5 and Psycopg2 >= 2.5.4.
 - [Available on pypi](https://pypi.python.org/pypi/django-modeltrans)
 - [Documentation](http://django-modeltrans.readthedocs.io/en/latest/)

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -3,12 +3,6 @@ from django.db.models import F, fields
 from django.db.models.functions import Cast, Coalesce
 from django.utils.translation import gettext_lazy as _
 
-try:
-    from django.db.models import JSONField, KeyTextTransform  # django==3.1 moved json field
-except ImportError:
-    from django.contrib.postgres.fields import JSONField
-    from django.contrib.postgres.fields.jsonb import KeyTextTransform
-
 from .conf import get_default_language, get_fallback_chain, get_modeltrans_setting
 from .utils import (
     FallbackTransform,
@@ -16,6 +10,13 @@ from .utils import (
     get_instance_field_value,
     get_language,
 )
+
+try:
+    from django.db.models import JSONField, KeyTextTransform  # django==3.1 moved json field
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
+    from django.contrib.postgres.fields.jsonb import KeyTextTransform
+
 
 SUPPORTED_FIELDS = (fields.CharField, fields.TextField)
 

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -1,8 +1,13 @@
-from django.contrib.postgres.fields.jsonb import JSONField, KeyTextTransform
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import F, fields
 from django.db.models.functions import Cast, Coalesce
 from django.utils.translation import gettext_lazy as _
+
+try:
+    from django.db.models import JSONField, KeyTextTransform  # django==3.1 moved json field
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
+    from django.contrib.postgres.fields.jsonb import KeyTextTransform
 
 from .conf import get_default_language, get_fallback_chain, get_modeltrans_setting
 from .utils import (

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,6 +1,10 @@
-from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+try:
+    from django.db.models import JSONField  # django==3.1 moved json field
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
 
 from modeltrans.fields import TranslationField
 from modeltrans.manager import MultilingualManager

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,13 +1,14 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from modeltrans.fields import TranslationField
+from modeltrans.manager import MultilingualManager
+
 try:
     from django.db.models import JSONField  # django==3.1 moved json field
 except ImportError:
     from django.contrib.postgres.fields import JSONField
 
-from modeltrans.fields import TranslationField
-from modeltrans.manager import MultilingualManager
 
 
 class CategoryQueryset(models.QuerySet):

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -10,7 +10,6 @@ except ImportError:
     from django.contrib.postgres.fields import JSONField
 
 
-
 class CategoryQueryset(models.QuerySet):
     """
     Custom manager to make sure pickling on-the-fly created classes

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
 deps =
     2.2: Django==2.2.*
     3.0: Django==3.0.*
+    3.1: Django==3.1.*
     master: https://github.com/django/django/archive/master.tar.gz
     psycopg2-binary
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,10 @@
 args_are_paths = false
 envlist =
     py35-{2.2},
-    py36-{2.2,3.0,master},
-    py37-{2.2,3.0,master},
-    py38-{3.0,master},
+    py36-{2.2,3.0,3.1,master},
+    py37-{2.2,3.0,3.1,master},
+    py38-{3.0,3.1,master},
+    py39-{3.0,3.1,master},
     migrate,
     flake8,
     isort,


### PR DESCRIPTION
fixes: #64

https://docs.djangoproject.com/en/3.1/releases/3.1/

results (locally) in a lot of errors, please have a look.