### PR TITLE
Drop django 3.0 support, add django 3.2 support, pin pyscopg2-binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.0, 3.1, 3.2]
+        django-version: [2.2, 3.1, 3.2]
         exclude:
             - python-version: 3.8
               django-version: 2.2
@@ -58,5 +58,5 @@ jobs:
         if: matrix.django-version == 'master'
       - run: |
           python -m pip install coverage
-          python -m pip install psycopg2-binary
+          python -m pip install psycopg2-binary==2.8.6
       - run: coverage run --source=modeltrans manage.py test

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@
 args_are_paths = false
 envlist =
     py35-{2.2},
-    py36-{2.2,3.0,3.1,master},
-    py37-{2.2,3.0,3.1,master},
-    py38-{3.0,3.1,master},
-    py39-{3.0,3.1,master},
+    py36-{2.2,3.1,master},
+    py37-{2.2,3.1,master},
+    py38-{3.1,3.2,master},
+    py39-{3.1,3.2,master},
     migrate,
     flake8,
     isort,
@@ -29,10 +29,10 @@ commands =
     coverage run ./manage.py test --no-input
 deps =
     2.2: Django==2.2.*
-    3.0: Django==3.0.*
     3.1: Django==3.1.*
+    3.2: Django==3.2.*
     master: https://github.com/django/django/archive/master.tar.gz
-    psycopg2-binary
+    psycopg2-binary==2.8.6
     coverage
 
 [testenv:migrate]


### PR DESCRIPTION
cc @danielvdp 

You did pin `psycopg2-binary` in `tox.ini`, but not in `.github/ci.yml `