### PR TITLE
TranslationModelFrom: change default languages to include fallback

### DIFF
--- a/docs/pages/translation-model-form.rst
+++ b/docs/pages/translation-model-form.rst
@@ -38,6 +38,7 @@ Setting the form languages
         - `"browser"`: the language that is active in the browser session
         - `"fallback"`: the fallback language either defined in the form, the model instance, or in the system, in that order of priority
         - a language code: e.g. `"fr"`, `"it"`
+    - Default: `["browser", "fallback"]`
     - Ordering: the ordering defined in the declaration is preserved
     - Duplicate languages are removed, e.g. `["browser", "fr", "fallback"]`, becomes `["fr"]` if browser language and fallback are also `"fr"`.
 

--- a/modeltrans/forms.py
+++ b/modeltrans/forms.py
@@ -16,7 +16,7 @@ class TranslationModelFormOptions(forms.models.ModelFormOptions):
 
     def __init__(self, options=None):
         super().__init__(options)
-        self.languages = getattr(options, "languages", ["browser"])
+        self.languages = getattr(options, "languages", ["browser", "fallback"])
         self.fallback_language = getattr(options, "fallback_language", None)
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -91,7 +91,7 @@ class TranslationModelFormTestCase(TestCase):
     def test_defaults(self):
         """Test the default form options."""
         form = Form()
-        self.assertEqual(form.languages, ["browser"])
+        self.assertEqual(form.languages, ["browser", "fallback"])
         self.assertEqual(form.fallback_language, get_default_language())
 
     def test_get_fallback_language(self):


### PR DESCRIPTION
This PR changes the default for `languages` from `["browser"]` to `["browser", "fallback"]`