### PR TITLE
Translation form: customizable field labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 django-modeltrans change log
 ============================
 
+## 0.7.1 (2021-07-20)
+ - Add customizable field labels to `TranslationModelForm`
+
 ## 0.7.0 (2021-06-30)
  - Add `TranslationModelForm`
 

--- a/docs/pages/translation-model-form.rst
+++ b/docs/pages/translation-model-form.rst
@@ -71,4 +71,9 @@ The label of the field is adjusted to include the relevant language
 and to designate the field as a translation or default fallback field, as follows:
 
   - translation fields: "field name (NL, translation language)"
-  - fallback field: "field name (EN, default language)"
+  - fallback field: "field name (EN, fallback language)"
+
+The labels "translation language" and "fallback language" are customizable using the `Meta` options:
+
+  - `fallback_label` (defaults to "fallback language")
+  - `translation_label` (defaults to "translation language")

--- a/modeltrans/forms.py
+++ b/modeltrans/forms.py
@@ -18,6 +18,10 @@ class TranslationModelFormOptions(forms.models.ModelFormOptions):
         super().__init__(options)
         self.languages = getattr(options, "languages", ["browser", "fallback"])
         self.fallback_language = getattr(options, "fallback_language", None)
+        self.labels = {
+            "fallback": getattr(options, "fallback_label", _("fallback language")),
+            "translation": getattr(options, "translation_label", _("translation language")),
+        }
 
 
 class TranslationModelFormMetaClass(forms.models.ModelFormMetaclass):
@@ -202,6 +206,7 @@ class TranslationModelForm(forms.ModelForm, metaclass=TranslationModelFormMetaCl
 
         self.model_i18n_field = get_i18n_field(self._meta.model)
         self.languages = languages or self._meta.languages
+        self.labels = self._meta.labels
         self.i18n_fields = [
             field for field in self.model_i18n_field.fields if field in self.base_fields.keys()
         ]
@@ -245,7 +250,9 @@ class TranslationModelForm(forms.ModelForm, metaclass=TranslationModelFormMetaCl
                 if field_name != original_field_name:
                     language = field_name.replace(f"{original_field_name}_", "")
                 is_translation = language != self.fallback_language
-                label_text = _("translation language") if is_translation else _("default language")
+                label_text = (
+                    self.labels["translation"] if is_translation else self.labels["fallback"]
+                )
                 label = f"{original_field.label} ({language.upper()}, {label_text})"
                 self.fields[field_name].label = label
                 self.fields[field_name].required = (

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -219,7 +219,7 @@ class TranslationModelFormTestCase(TestCase):
         """Test that fields are set with the correct properties."""
         with self.subTest("Browser (fallback) language"):
             title_field = Form().fields["title"]
-            self.assertEqual(title_field.label, "Title (EN, default language)")
+            self.assertEqual(title_field.label, "Title (EN, fallback language)")
             self.assertTrue(title_field.required)
 
         with self.subTest("Custom (fallback) language"):
@@ -236,9 +236,26 @@ class TranslationModelFormTestCase(TestCase):
             self.assertEqual(title_de_field.widget.__class__, forms.widgets.Textarea)
 
             title_fr_field = form.fields["title_fr"]
-            self.assertEqual(title_fr_field.label, "Title (FR, default language)")
+            self.assertEqual(title_fr_field.label, "Title (FR, fallback language)")
             self.assertEqual(title_fr_field.required, True)
             self.assertEqual(title_fr_field.widget.__class__, forms.widgets.Textarea)
+
+        with self.subTest("Custom labels"):
+
+            class CustomLabelForm(TranslationModelForm):
+                class Meta:
+                    model = Challenge
+                    fields = ["title"]
+                    languages = ["browser", "fallback"]
+                    fallback_language = "fr"
+                    fallback_label = "default language"
+                    translation_label = "new language"
+
+            form = CustomLabelForm()
+            title_field = form.fields["title"]
+            self.assertEqual(title_field.label, "Title (EN, new language)")
+            title_field = form.fields["title_fr"]
+            self.assertEqual(title_field.label, "Title (FR, default language)")
 
     def test_form_initial_values(self):
         challenge = Challenge.objects.create(title="english", title_fr="french")


### PR DESCRIPTION
This PR adds customizable labels to the TranslationModelForm as Meta options.

Fixes: https://github.com/zostera/django-modeltrans/issues/70