### PR TITLE
Use `TranslationModelForm` to implement `ActiveLanguageMixin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Translates Django model fields in a `JSONField` using a registration approach.
 
 - Uses one PostgreSQL `jsonb`-field per model.
   (`django.contrib.postgres.JSONField` for Django<3.1, `django.db.models.JSONField` for Django>=3.1)
-- Django 2.2, 3.0, 3.1 (with their supported python versions)
+- Django 2.2, 3.0, 3.1, 3.2, 4.0 (with their supported python versions)
 - PostgreSQL >= 9.5 and Psycopg2 >= 2.5.4.
 - [Available on pypi](https://pypi.python.org/pypi/django-modeltrans)
 - [Documentation](http://django-modeltrans.readthedocs.io/en/latest/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,14 +24,14 @@ Table of contents
     :caption: Documentation
 
     pages/getting-started
-    pages/translation-model-form
+    pages/forms
+    pages/admin
     pages/working-with-models
     pages/performance
     pages/inner-workings
     pages/known-issues
     pages/related-packages
     pages/management
-    pages/admin
 
 .. toctree::
     :maxdepth: 1

--- a/docs/pages/admin.rst
+++ b/docs/pages/admin.rst
@@ -7,7 +7,7 @@ By default, each field is displayed for each language configured for django-mode
 This might work for a couple of languages, but with 2 translated fields and 10 languages,
 it already is a bit unwieldy.
 
-A mixin is provided to show only the default language (`settings.LANGUAGE_CODE`) and
+The `ActiveLanguageMixin` is provided to show only the default language (`settings.LANGUAGE_CODE`) and
 the currently active language. Use like this::
 
     from django.contrib import admin
@@ -21,8 +21,8 @@ the currently active language. Use like this::
         pass
 
 
-This uses `modeltrans.forms.TranslationModelForm`, if you need more customization,
-it can be used directly::
+`ActiveLanguageMixin` uses `modeltrans.forms.TranslationModelForm`, if you need more customization,
+the latter can be used directly::
 
     from modeltrans.forms import TranslationModelForm
 

--- a/docs/pages/admin.rst
+++ b/docs/pages/admin.rst
@@ -1,13 +1,13 @@
 .. _admin:
 
-Admin support
-=============
+Admin
+=====
 
 By default, each field is displayed for each language configured for django-modeltrans.
 This might work for a couple of languages, but with 2 translated fields and 10 languages,
 it already is a bit unwieldy.
 
-A mixin is provided to show only the default language (settings.LANGUAGE_CODE) and
+A mixin is provided to show only the default language (`settings.LANGUAGE_CODE`) and
 the currently active language. Use like this::
 
     from django.contrib import admin
@@ -19,3 +19,17 @@ the currently active language. Use like this::
     @admin.register(Blog)
     class BlogAdmin(ActiveLanguageMixin, admin.ModelAdmin):
         pass
+
+
+This uses `modeltrans.forms.TranslationModelForm`, if you need more customization,
+it can be used directly::
+
+    from modeltrans.forms import TranslationModelForm
+
+    class BlogForm(TranslationModelForm):
+        pass
+
+
+    @admin.register(Blog)
+    class BlogAdmin(admin.ModelAdmin):
+        form_class = BlogForm

--- a/docs/pages/forms.rst
+++ b/docs/pages/forms.rst
@@ -1,7 +1,7 @@
-Translations in forms
-=====================
+Forms
+=====
 
-`TranslationModelForm` is an adaptation of Django's `django.forms.ModelForm` that allows management of translation fields.
+`~.forms.TranslationModelForm` is an adaptation of Django's `django.forms.ModelForm` that allows management of translation fields.
 Assuming your model is translated with modeltrans,
 you can use `TranslationModelForm` to specify which languages to include form fields for.
 

--- a/modeltrans/admin.py
+++ b/modeltrans/admin.py
@@ -1,35 +1,9 @@
-from .conf import get_default_language
-from .translator import get_i18n_field
-from .utils import get_language
+from .forms import TranslationModelForm
 
 
-class ActiveLanguageMixin(object):
+class ActiveLanguageMixin:
     """
-    Add this mixin to your admin class to exclude all virtual fields, except:
-
-     - The original field (for the default language, settings.LANGUAGE_CODE)
-     - The field for the currently active language, without fallback.
+    ModelAdmin mixin to only show fields for the fallback and current language in the change view.
     """
 
-    def get_exclude(self, request, obj=None):
-        i18n_field = get_i18n_field(self.model)
-        # use default implementation for models without i18n-field
-        if i18n_field is None:
-            return super().get_exclude(request)
-
-        language = get_language()
-        if language == get_default_language():
-            language = False
-
-        excludes = []
-        for field in i18n_field.get_translated_fields():
-            # Not excluded:
-            # - language is None: the _i18n-version of the field.
-            # - language equals the current language
-            if field.language == language:
-                continue
-
-            excludes.append(field.name)
-
-        # de-duplicate
-        return list(set(excludes))
+    form_class = TranslationModelForm


### PR DESCRIPTION
I noticed the current implementation of `ActiveLanguageMixin` worked very poorly, using `TranslationModelForm` did what this was supposed to do.

Also some touchups in the docs.

