### PR TITLE
Per-record default language

### DIFF
--- a/docs/pages/working-with-models.rst
+++ b/docs/pages/working-with-models.rst
@@ -99,6 +99,11 @@ achieve this, you have two options:
   one for all models. If you don't set `MODELTRANS_FALLBACK["default"]`, `(LANGUAGE_CODE,)` will be used, which means
   that the global default language will have precedence over the per-record default language.
 
+**Caveat:** Changing the default language for instances cannot be easily done at the moment. When you change the default
+language, you must manually move the original field values to the JSON field and the other way around. Be aware that
+changing the default language of an instance may affect instances from other models as well if their
+`default_language_field` refers to the changed instance via foreign keys (using the `__` syntax).
+
 
 Inheritance of models with translated fields.
 ---------------------------------------------

--- a/docs/pages/working-with-models.rst
+++ b/docs/pages/working-with-models.rst
@@ -46,6 +46,60 @@ With the models above::
         print(article.content)  # 'VS-Europeese oceaanbewakingssatelliet gelanceerd'
 
 
+Per-record default language
+---------------------------
+
+The value of an original field (a translatable field when used without a language suffix; for example `title`, but not
+`title_nl`) is normally in the Django default language, which is the one specified by the setting `LANGUAGE_CODE`.
+Translations to any other language will be stored in the model's implicitly generated JSON field. In some cases, it may
+be desired to use per-record default languages instead of a single global default language. For example, for a model
+for organizations from different parts of the world, each instance has a name that is in the respective local language
+and it may be desired to use this local-language name by default instead of storing it in the JSON field and leaving the
+original field empty for potentially many instances. Modeltrans supports this by using the argument
+`default_language_field` when specifying a `TranslationField`::
+
+    class Organization(models.Model):
+        name = models.CharField(max_length=255)
+        language = models.CharField(max_length=2)
+        i18n = TranslationField(fields=("name",), default_language_field="language")
+
+Now, no matter the `LANGUAGE_CODE` setting, for both of the following instances the `name` field will contain the local
+name and the JSON field `i18n` will be empty::
+
+    amsterdam = Organization.objects.create(name="Gemeente Amsterdam", language="nl")
+    helsinki = Organization.objects.create(name="Helsingin kaupunki", language="fi")
+
+In addition, the names are also available in `amsterdam.name_nl` and `helsinki.name_fi`.
+
+The value of `default_language_field` can contain `__` to traverse foreign keys::
+
+    class Department(models.Model):
+        name = models.CharField(max_length=255)
+        organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+        i18n = TranslationField(fields=("name",), default_language_field="organization__language")
+
+Care should be taken regarding fallback. When you access the virtual field `name_i18n`, the following steps are taken to
+return a value:
+
+1. If the instance has a name in the currently active Django language, this value will be used.
+2. If the model has a `fallback_language_field` and a name exists in the language stored in this field, that value will
+   be used.
+3. The languages in the fallback chain (as specified in the setting `MODELTRANS_FALLBACK`) will be tried and the first
+   found value will be returned.
+4. If no name for any of the previously tried languages exists, the value of the original field `name` will be used.
+
+Therefore, if you specified a `default_language_field`, you should keep in mind that the fallback chain will take effect
+before the original field value is returned. When using `default_language_field`, sometimes the desired behavior is to
+first try to get a value in the currently active language and, if this is impossible, fall back to the per-record
+default language stored in the original field instead of falling back to whatever is the global default language. To
+achieve this, you have two options:
+
+- In addition to `default_language_field="<field>"`, also specify `fallback_language_field="<field>"`.
+- Set `MODELTRANS_FALLBACK["default"]` to the empty tuple `()` to disable fallback to languages other than the original
+  one for all models. If you don't set `MODELTRANS_FALLBACK["default"]`, `(LANGUAGE_CODE,)` will be used, which means
+  that the global default language will have precedence over the per-record default language.
+
+
 Inheritance of models with translated fields.
 ---------------------------------------------
 

--- a/modeltrans/forms.py
+++ b/modeltrans/forms.py
@@ -64,13 +64,16 @@ class TranslationModelFormMetaClass(forms.models.ModelFormMetaclass):
         if model_class:
             i18n_field = get_i18n_field(model_class)
             if i18n_field:
+                has_default_language_field = bool(i18n_field.default_language_field)
 
                 for original_field_name in i18n_field.fields:  # for all translated fields
 
                     # for all possible system languages
                     for language in languages:
+                        # Ignore the default language suffix (and use the original field) only if the field has no
+                        # specified default_language_field because, if it does, we don't know the default language
                         field_name = build_localized_fieldname(
-                            original_field_name, language, ignore_default=True
+                            original_field_name, language, ignore_default=not has_default_language_field
                         )
 
                         # add i18n field if an explicitly chosen field
@@ -227,9 +230,12 @@ class TranslationModelForm(forms.ModelForm, metaclass=TranslationModelFormMetaCl
         """
 
         fields = {}
+        has_default_language_field = bool(self.model_i18n_field.default_language_field)
         for original_field in self.i18n_fields:
+            # Ignore the default language suffix (and use the original field) only if the field has no
+            # specified default_language_field because, if it does, we don't know the default language
             fields[original_field] = [
-                build_localized_fieldname(original_field, language_code, ignore_default=True)
+                build_localized_fieldname(original_field, language_code, ignore_default=not has_default_language_field)
                 for language_code in self.language_codes
             ]
         fields["__all__"] = list(itertools.chain.from_iterable(fields.values()))

--- a/modeltrans/manager.py
+++ b/modeltrans/manager.py
@@ -6,7 +6,7 @@ from django.db.models.functions import Cast
 
 from .conf import get_default_language
 from .fields import TranslatedVirtualField
-from .utils import DJANGO_VERSION
+from .utils import DJANGO_VERSION, get_instance_field_value
 
 
 def transform_translatable_fields(model, fields):
@@ -39,7 +39,16 @@ def transform_translatable_fields(model, fields):
 
         if isinstance(field, TranslatedVirtualField):
             has_translated_fields = True
-            if field.get_language() == get_default_language():
+            if field.default_language_field:
+                first_part, *path = field.default_language_field.split(LOOKUP_SEP, maxsplit=1)
+                if path:
+                    assert len(path) == 1
+                    default_language = get_instance_field_value(fields[first_part], path[0])
+                else:
+                    default_language = fields[first_part]
+            else:
+                default_language = get_default_language()
+            if field.get_language() == default_language:
                 if field.original_name in fields:
                     raise ValueError(
                         'Attempted override of "{}" with "{}". '
@@ -329,7 +338,7 @@ class MultilingualQuerySet(QuerySet):
 
             fallback = field.language is None
 
-            if field.get_language() == get_default_language():
+            if not field.default_language_field and field.get_language() == get_default_language():
                 original_field = field_name.replace(field.name, field.original_field.name)
                 self.query.add_annotation(Cast(original_field, field.output_field()), field_name)
             else:

--- a/modeltrans/utils.py
+++ b/modeltrans/utils.py
@@ -32,12 +32,14 @@ def split_translated_fieldname(field_name):
     return (field_name[0:_pos], field_name[_pos + 1 :])
 
 
-def build_localized_fieldname(field_name, lang, ignore_default=False):
+def build_localized_fieldname(field_name, lang, ignore_default=False, default_language=None):
+    if default_language is None:
+        default_language = get_default_language()
     if lang == "id":
         # The 2-letter Indonesian language code is problematic with the
         # current naming scheme as Django foreign keys also add "id" suffix.
         lang = "ind"
-    if ignore_default and lang == get_default_language():
+    if ignore_default and lang == default_language:
         return field_name
     return "{}_{}".format(field_name, lang.replace("-", "_"))
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -198,3 +198,27 @@ class ChallengeContent(models.Model):
 
     def __str__(self):
         return self.content_i18n
+
+
+class Organization(models.Model):
+    """Model using a custom default language per instance/record."""
+
+    name = models.CharField(max_length=255)
+    language = models.CharField(max_length=2, null=True, blank=True, default=get_default_language())
+
+    i18n = TranslationField(fields=("name",), default_language_field="language")
+
+    def __str__(self):
+        return self.name_i18n
+
+
+class Department(models.Model):
+    """Model using a custom default language on a related record."""
+
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    name = models.CharField(max_length=255)
+
+    i18n = TranslationField(fields=("name",), default_language_field="organization__language")
+
+    def __str__(self):
+        return self.name_i18n

--- a/tests/test_translating.py
+++ b/tests/test_translating.py
@@ -44,6 +44,8 @@ class Translating_utils(TestCase):
             app_models.Choice,
             app_models.Challenge,
             app_models.ChallengeContent,
+            app_models.Organization,
+            app_models.Department,
         }
         self.assertEqual(set(get_translated_models("app")), expected)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from modeltrans.utils import (
     split_translated_fieldname,
 )
 
-from .app.models import Blog, Category
+from .app.models import Blog, Category, Department, Organization
 
 
 class UtilsTest(TestCase):
@@ -46,6 +46,52 @@ class UtilsTest(TestCase):
                 Blog, {"title": "bar", "title_de": "das foo", "i18n": {"title_nl": "foo"}}
             ),
             {"i18n": {"title_nl": "foo", "title_de": "das foo"}, "title": "bar"},
+        )
+
+    def test_transform_translatable_fields_with_default_language_field(self):
+        self.assertEqual(
+            transform_translatable_fields(
+                Organization,
+                {"language": "de", "name": "das foo", "name_nl": "foo", "i18n": {"name_en": "bar"}},
+            ),
+            {"language": "de", "name": "das foo", "i18n": {"name_nl": "foo", "name_en": "bar"}},
+        )
+
+    def test_transform_translatable_fields_with_default_language_field_explicit(
+        self,
+    ):
+        self.assertEqual(
+            transform_translatable_fields(
+                Organization,
+                {
+                    "language": "de",
+                    "name_de": "das foo",
+                    "i18n": {},
+                },
+            ),
+            {"language": "de", "name": "das foo", "i18n": {}},
+        )
+
+    def test_transform_translatable_fields_with_default_language_field_raises_if_override(self):
+        with self.assertRaises(ValueError):
+            transform_translatable_fields(
+                Organization,
+                {"language": "de", "name": "das foo", "name_de": "die foo"},
+            )
+
+    def test_transform_translatable_fields_with_default_language_field_in_related_model(self):
+        org = Organization(language="de")
+        self.assertEqual(
+            transform_translatable_fields(
+                Department,
+                {
+                    "organization": org,
+                    "name": "das foo",
+                    "name_en": "bar",
+                    "i18n": {"name_nl": "foo"},
+                },
+            ),
+            {"organization": org, "name": "das foo", "i18n": {"name_en": "bar", "name_nl": "foo"}},
         )
 
     def test_build_localized_fieldname(self):


### PR DESCRIPTION
So far, modeltrans assumed that the value of an original field (a translatable field when used without a language suffix; for example `title`, but not `title_nl`) is in the Django default language, which is the one specified by the setting `LANGUAGE_CODE`. Translations to any other language will be stored in the model's implicitly generated JSON field.

In some cases, it may be desired to use per-record default languages instead of a single global default language. For example, for a model for organizations from different parts of the world, each instance has a name that is in the respective local language and it may be desired to use this local-language name by default instead of storing it in the JSON field and leaving the original field empty for potentially many instances.

This PR adds an argument `default_language_field` to `TranslationField` that allows users to refer to a field that specifies the language of the original field. The default language field can be either in the same instance or in another reachable via foreign keys using the `__` syntax.

Example:

```
class Organization(models.Model):
    name = models.CharField(max_length=255)
    language = models.CharField(max_length=2)
    i18n = TranslationField(fields=("name",), default_language_field="language")

class Department(models.Model):
    name = models.CharField(max_length=255)
    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
    i18n = TranslationField(fields=("name",), default_language_field="organization__language")
```

Now, no matter the `LANGUAGE_CODE` setting, for both of the following instances the `name` field will contain the local
name and the JSON field `i18n` will be empty:

```
amsterdam = Organization.objects.create(name="Gemeente Amsterdam", language="nl")
helsinki = Organization.objects.create(name="Helsingin kaupunki", language="fi")
```

In addition, the names are also available in `amsterdam.name_nl` and `helsinki.name_fi`.

Please see the documentation for this feature (`docs/pages/working-with-models.rst`) for some caveats.

In particular, changing the default language is not supported at the moment because it's nontrivial when `__` is used in `default_language_field`, but if there is interest in that I could try writing some code for that as well.

I also found what could be considered a bug in modeltrans (issue #84). So far, the current PR fixes it when `default_language_field` is used, but it doesn't change the behavior when `default_language_field` is not used in order to keep the behavior the same for existing applications. Perhaps it would be a good idea to make this the default behavior, however.

I'm happy to receive feedback and make some changes if needed.