### PR TITLE
Update Django versions and CI link in README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # django-modeltrans
 
-[![Travis CI](https://travis-ci.org/zostera/django-modeltrans.svg?branch=master)](https://travis-ci.org/zostera/django-modeltrans)
+[![CI](https://github.com/zostera/django-modeltrans/actions/workflows/ci.yml/badge.svg)](https://github.com/zostera/django-modeltrans/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/django-modeltrans/badge/?version=latest)](http://django-modeltrans.readthedocs.io/en/latest/?badge=latest)
 [![Any color you like](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
@@ -8,9 +8,8 @@ Translates Django model fields in a `JSONField` using a registration approach.
 
 # Features/requirements
 
-- Uses one PostgreSQL `jsonb`-field per model.
-  (`django.contrib.postgres.JSONField` for Django<3.1, `django.db.models.JSONField` for Django>=3.1)
-- Django 2.2, 3.0, 3.1, 3.2, 4.0 (with their supported python versions)
+- Uses one PostgreSQL `jsonb`-field per model (via `django.db.models.JSONField`)
+- Django 3.2, 4.0, 4.1, 4.2 (with their supported python versions)
 - PostgreSQL >= 9.5 and Psycopg2 >= 2.5.4.
 - [Available on pypi](https://pypi.python.org/pypi/django-modeltrans)
 - [Documentation](http://django-modeltrans.readthedocs.io/en/latest/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,8 @@
 django-modeltrans - Translate model fields using a `JSONField`
 ==============================================================
 
-- Uses one `django.contrib.postgres.JSONField` (PostgreSQL JSONB field) for every record.
-- Django 1.11 and 2.0 (with their supported python versions)
+- Uses one `django.db.models.JSONField` (PostgreSQL JSONB field) for every record.
+- Django Django 3.2, 4.0, 4.1, 4.2 (with their supported python versions)
 - PostgreSQL >= 9.5 and Psycopg2 >= 2.5.4.
 
 About the app:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ django-modeltrans - Translate model fields using a `JSONField`
 About the app:
 
 - `Available on pypi <https://pypi.python.org/pypi/django-modeltrans>`_
-- Tested using `Travis CI <https://travis-ci.org/zostera/django-modeltrans>`_
+- Tested using `GitHub actions <https://github.com/zostera/django-modeltrans/actions>`_
 - `Documentation on readthedocs.org <https://django-modeltrans.readthedocs.io/en/latest/>`_
 - `Bug tracker <http://github.com/zostera/django-modeltrans/issues>`_
 

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import F, fields
+from django.db.models import F, JSONField, fields
+from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Coalesce
 from django.utils.translation import gettext
 
@@ -10,15 +11,6 @@ from .utils import (
     get_instance_field_value,
     get_language,
 )
-
-try:
-    # django==3.1 moved JSONField into django.db.models
-    from django.db.models import JSONField
-    from django.db.models.fields.json import KeyTextTransform
-except ImportError:
-    from django.contrib.postgres.fields import JSONField
-    from django.contrib.postgres.fields.jsonb import KeyTextTransform
-
 
 SUPPORTED_FIELDS = (fields.CharField, fields.TextField)
 

--- a/modeltrans/utils.py
+++ b/modeltrans/utils.py
@@ -1,14 +1,10 @@
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.fields.json import KeyTransform
 from django.db.models.lookups import Transform
 from django.utils.translation import get_language as _get_language
 
 from .conf import get_available_languages, get_default_language
-
-try:
-    from django.db.models.fields.json import KeyTransform
-except ImportError:
-    from django.contrib.postgres.fields.jsonb import KeyTransform
 
 
 def get_language():


### PR DESCRIPTION
Not sure if you also want to remove the fallback code for Django < 3.1:

https://github.com/zostera/django-modeltrans/blob/07c3dd187420a5a73bdade3e3853005e91929635/modeltrans/fields.py#L14-L20