### PR TITLE
Add config file for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+# Declare the Python requirements required to build your documentation
+python:
+  install:
+  - requirements: docs/requirements.txt
+
+# Build documentation in the docs directory with Sphinx
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Declare the Python requirements required to build your documentation
 python:


### PR DESCRIPTION
The RTD build [fails](https://readthedocs.org/projects/django-modeltrans/builds/21613194/)

<img width="909" alt="image" src="https://github.com/zostera/django-modeltrans/assets/861044/9729699d-d255-4da8-ac5c-8280ca631963">

> The configuration file required to build documentation is missing from your project. Add a configuration file to your project to make it build successfully. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html

Adding a basic config file to fix it.

You might want to enable PR build in the settings: https://readthedocs.org/dashboard/django-modeltrans/advanced/

<img width="370" alt="image" src="https://github.com/zostera/django-modeltrans/assets/861044/75137167-e0a2-4a60-9933-ba2e20101968">
