### PR TITLE
Fix blank fields trying to insert NULL

### DIFF
--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -16,7 +16,7 @@ Getting started
 
     class Blog(models.Model):
         title = models.CharField(max_length=255)
-        body = models.TextField(null=True)
+        body = models.TextField(blank=True)
 
         i18n = TranslationField(fields=("title", "body"))
 

--- a/docs/pages/inner-workings.rst
+++ b/docs/pages/inner-workings.rst
@@ -11,7 +11,7 @@ The inner workings are illustrated using this model::
 
     class Blog(models.Model):
         title = models.CharField(max_length=255)
-        body = models.TextField(null=True)
+        body = models.TextField(blank=True)
 
         i18n = TranslationField(fields=("title", "body"))
 

--- a/docs/pages/known-issues.rst
+++ b/docs/pages/known-issues.rst
@@ -60,7 +60,7 @@ For example, ``Category`` needs ``objects = MultilingualManager()`` in order to 
 
     class Blog(models.Model):
         title = models.CharField(max_length=255)
-        body = models.TextField(null=True)
+        body = models.TextField(blank=True)
         category = models.ForeignKey(Category, null=True, blank=True, on_delete=models.CASCADE)
 
         i18n = TranslationField(fields=("title", "body"))

--- a/docs/pages/migration.rst
+++ b/docs/pages/migration.rst
@@ -27,7 +27,7 @@ This is how to migrate from django-modeltranslation (version 0.12.1) to
 
     class Blog(models.Model):
         title = models.CharField(max_length=255)
-        body = models.TextField(null=True)
+        body = models.TextField(blank=True)
 
         # add this field, containing the TranslationOptions attributes as arguments:
         i18n = TranslationField(fields=('title', 'body'), virtual_fields=False)

--- a/modeltrans/translator.py
+++ b/modeltrans/translator.py
@@ -154,7 +154,10 @@ def add_virtual_fields(Model, fields, required_languages):
         # first, add a `<original_field_name>_i18n` virtual field to get the currently
         # active translation for a field
         field = translated_field_factory(
-            original_field=original_field, blank=True, null=True, editable=False  # disable in admin
+            original_field=original_field,
+            blank=True,
+            null=original_field.null,
+            editable=False,  # disable in admin
         )
 
         raise_if_field_exists(Model, field.get_field_name())
@@ -166,7 +169,7 @@ def add_virtual_fields(Model, fields, required_languages):
             original_field=original_field,
             language=get_default_language(),
             blank=True,
-            null=True,
+            null=original_field.null,
             editable=False,
         )
         raise_if_field_exists(Model, field.get_field_name())
@@ -181,7 +184,7 @@ def add_virtual_fields(Model, fields, required_languages):
                 original_field=original_field,
                 language=language,
                 blank=blank_allowed,
-                null=blank_allowed,
+                null=blank_allowed and original_field.null,
             )
             raise_if_field_exists(Model, field.get_field_name())
             field.contribute_to_class(Model, field.get_field_name())

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -40,7 +40,7 @@ class Site(models.Model):
 
 class Blog(models.Model):
     title = models.CharField(max_length=255)
-    body = models.TextField(null=True)
+    body = models.TextField(blank=True)
 
     category = models.ForeignKey(Category, null=True, blank=True, on_delete=models.CASCADE)
     site = models.ForeignKey(Site, null=True, blank=True, on_delete=models.CASCADE)
@@ -171,7 +171,7 @@ class Challenge(models.Model):
     """Model using a custom fallback language per instance/record."""
 
     title = models.CharField(max_length=255)
-    header = models.CharField(max_length=255, null=True, blank=True)
+    header = models.CharField(max_length=255, blank=True)
 
     default_language = models.CharField(
         max_length=2, null=True, blank=True, default=get_default_language()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -262,7 +262,8 @@ class TranslationModelFormTestCase(TestCase):
 
             self.assertEqual(form["title"].initial, initial_data["title"])
             self.assertEqual(form["title_fr"].initial, initial_data["title_fr"])
-            self.assertIsNone(form["header"].initial)
+            # Empty initial data is always None
+            self.assertEqual(form["header"].initial, None)
             self.assertEqual(form["header_fr"].initial, initial_data["header_fr"])
             self.assertEqual(form["default_language"].initial, get_default_language())
 
@@ -271,7 +272,7 @@ class TranslationModelFormTestCase(TestCase):
 
             self.assertEqual(form["title"].initial, initial_data["title"])
             self.assertEqual(form["title_fr"].initial, initial_data["title_fr"])
-            self.assertIsNone(form["header"].initial)
+            self.assertEqual(form["header"].initial, "")
             self.assertEqual(form["header_fr"].initial, initial_data["header_fr"])
             self.assertEqual(form["default_language"].initial, get_default_language())
 
@@ -282,7 +283,7 @@ class TranslationModelFormTestCase(TestCase):
             self.assertTrue(form.is_valid())
             challenge = form.save()
             self.assertEqual(challenge.title, data["title"])
-            self.assertIsNone(challenge.header)
+            self.assertEqual(challenge.header, "")
 
             data = {"start_date": "2021-01-01", "end_date": "2021-02-02", "title_fr": "Un title"}
             form = ExcludeForm(data=data)
@@ -290,7 +291,7 @@ class TranslationModelFormTestCase(TestCase):
             challenge = form.save()
             self.assertEqual(challenge.title, "")
             self.assertEqual(challenge.title_fr, data["title_fr"])
-            self.assertIsNone(challenge.header)
+            self.assertEqual(challenge.header, "")
 
         with self.subTest("Test that only fallback is required"):
             data = {"start_date": "2021-01-01", "end_date": "2021-02-02"}
@@ -315,9 +316,9 @@ class TranslationModelFormTestCase(TestCase):
             challenge = form.save()
             self.assertEqual(challenge.title_nl, data["title_nl"])
             self.assertEqual(challenge.title_de, data["title_de"])
-            self.assertIsNone(challenge.title_fr)
+            self.assertEqual(challenge.title_fr, "")
             self.assertEqual(challenge.title, "")
-            self.assertIsNone(challenge.header)
+            self.assertEqual(challenge.header, "")
 
             data = {
                 "start_date": "2021-01-01",
@@ -330,9 +331,9 @@ class TranslationModelFormTestCase(TestCase):
             challenge = form.save()
             self.assertEqual(challenge.title_nl, data["title_nl"])
             self.assertEqual(challenge.title_fr, data["title_fr"])
-            self.assertIsNone(challenge.title_de)
+            self.assertEqual(challenge.title_de, "")
             self.assertEqual(challenge.title, "")
-            self.assertIsNone(challenge.header)
+            self.assertEqual(challenge.header, "")
 
         with self.subTest("Update existing instance"):
             challenge = Challenge.objects.create(


### PR DESCRIPTION
A fix that prevents IntegrityErrors when trying to save a translated field with `blank=True` and `null=False`. 
Previously it would always try to insert NULL into the database.

[Django strongly recommends using empty strings instead of NULL for textual fields.](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.Field.null)