### PR TITLE
Add MODELTRANS_DEFAULT_LANGUAGE setting

### DIFF
--- a/docs/pages/inner-workings.rst
+++ b/docs/pages/inner-workings.rst
@@ -76,7 +76,7 @@ language is defined::
     # 'Valk', None
 
 The virtual field ``<field>_i18n`` returns the translated value for the current
-active language and falls back to the language in ``LANGUAGE_CODE``::
+active language and falls back to the language in ``MODELTRANS_DEFAULT_LANGUAGE``::
 
     with override("nl"):
         print(b.title_i18n)
@@ -88,7 +88,7 @@ active language and falls back to the language in ``LANGUAGE_CODE``::
 
     with override("fr"):
         print(b.title_i18n)
-    # 'Falcon' (no french translation available, falls back to LANGUAGE_CODE)
+    # 'Falcon' (no french translation available, falls back to MODELTRANS_DEFAULT_LANGUAGE)
 
 Django-modeltrans also allows ordering on translated values. Ordering on
 ``<field>_i18n`` probably makes most sense, as it more likely that there is a

--- a/docs/pages/settings.rst
+++ b/docs/pages/settings.rst
@@ -4,13 +4,25 @@ Settings Reference
 django-modeltrans allows some configuration to define its behavior.
 By default, it tries to use sensible defaults derived from the default django settings.
 
+
+``MODELTRANS_DEFAULT_LANGUAGE``
+----------------------------------
+A string representing the default language.  By default, the default language is set to
+django's `LANGUAGE_CODE setting <https://docs.djangoproject.com/en/stable/ref/settings/#language-code>`_.
+
+Customize this setting to change the default language used by django-modeltrans without impacting
+Django's translation / locale middlewares.
+
+See `#116 <https://github.com/zostera/django-modeltrans/issues/116>`_ for additional context.
+
+
 ``MODELTRANS_AVAILABLE_LANGUAGES``
 ----------------------------------
 A list of language codes to allow model fields to be translated in. By default,
 the language codes extracted from django's `LANGUAGES setting <https://docs.djangoproject.com/en/stable/ref/settings/#languages>`_.
 
 Note that
- - the default language, defined in django's `LANGUAGE_CODE setting <https://docs.djangoproject.com/en/stable/ref/settings/#language-code>`_,
+ - the default language, defined in `MODELTRANS_DEFAULT_LANGUAGE`,
    should not be added to this list (will be ignored).
  - order is not important
 
@@ -23,7 +35,7 @@ A custom definition might be::
 
 ``MODELTRANS_FALLBACK``
 -----------------------
-A dict of fallback chains as lists of languages. By default, it falls back to the language defined in django setting `LANGUAGE_CODE`.
+A dict of fallback chains as lists of languages. By default, it falls back to the language defined in `MODELTRANS_DEFAULT_LANGUAGE`.
 
 For example, django-modeltrans will fall back to:
  - english when the active language is 'nl'
@@ -31,10 +43,10 @@ For example, django-modeltrans will fall back to:
 
 If configured like this::
 
-    LANGUAGE_CODE = 'en'
+    MODELTRANS_DEFAULT_LANGUAGE = 'en'
     MODELTRANS_AVAILABLE_LANGUAGES = ('nl', 'fy')
     MODELTRANS_FALLBACK = {
-       'default': (LANGUAGE_CODE, ),
+       'default': (MODELTRANS_DEFAULT_LANGUAGE, ),
        'fy': ('nl', 'en')
     }
 

--- a/docs/pages/settings.rst
+++ b/docs/pages/settings.rst
@@ -22,8 +22,7 @@ A list of language codes to allow model fields to be translated in. By default,
 the language codes extracted from django's `LANGUAGES setting <https://docs.djangoproject.com/en/stable/ref/settings/#languages>`_.
 
 Note that
- - the default language, defined in `MODELTRANS_DEFAULT_LANGUAGE`,
-   should not be added to this list (will be ignored).
+ - the default language, defined in `MODELTRANS_DEFAULT_LANGUAGE` should not be added to this list (will be ignored).
  - order is not important
 
 A custom definition might be::

--- a/docs/pages/working-with-models.rst
+++ b/docs/pages/working-with-models.rst
@@ -7,7 +7,7 @@ Custom fallback language
 ------------------------
 
 By default, fallback is centrally configured with :ref:`settings_fallback`.
-That might not be sufficient, for example if part of the content is created for a single language which is not ``LANGUAGE_CODE``.
+That might not be sufficient, for example if part of the content is created for a single language which is not ``MODELTRANS_DEFAULT_LANGUAGE``.
 
 In that case, it can be configured per-record using the ``fallback_language_field`` argument to ``TranslationField``::
 
@@ -27,7 +27,7 @@ You can traverse foreign key relations too::
 
 Note that
  - if in this example no `newsroom` is set yet, the centrally configured fallback is used.
- - the original field _always_ contains the language as configured by ``LANGUAGE_CODE``.
+ - the original field _always_ contains the language as configured by ``MODELTRANS_DEFAULT_LANGUAGE``.
 
 With the models above::
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -12,6 +12,7 @@ ForeignKey
 fy
 german
 mixin
+middlewares
 modeltrans
 modeltranslation
 nl

--- a/modeltrans/conf.py
+++ b/modeltrans/conf.py
@@ -11,12 +11,13 @@ def get_modeltrans_setting(key):
             settings, "MODELTRANS_FALLBACK", {"default": (get_default_language(),)}
         ),
         "MODELTRANS_ADD_FIELD_HELP_TEXT": getattr(settings, "MODELTRANS_ADD_FIELD_HELP_TEXT", True),
+        "MODELTRANS_DEFAULT_LANGUAGE": get_default_language(),
     }
     return modeltrans_settings.get(key)
 
 
 def get_default_language():
-    return settings.LANGUAGE_CODE
+    return getattr(settings, "MODELTRANS_DEFAULT_LANGUAGE", getattr(settings, "LANGUAGE_CODE"))
 
 
 def get_available_languages_setting():

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -43,15 +43,11 @@ class FallbackConfTest(TestCase):
 
 
 class DefaultLanguageConfTest(TestCase):
-    @override_settings(
-        LANGUAGE_CODE="es", MODELTRANS_AVAILABLE_LANGUAGES=("nl", "de", "fr")
-    )
+    @override_settings(LANGUAGE_CODE="es", MODELTRANS_AVAILABLE_LANGUAGES=("nl", "de", "fr"))
     def test_django_language_code_not_available_language(self):
         message = 'Language "en" is in required_languages on Model "Person" but not in settings.MODELTRANS_AVAILABLE_LANGUAGES.'
         i18n_field = get_i18n_field(Person)
-        required_languages = get_i18n_field_param(
-            Person, i18n_field, "required_languages"
-        )
+        required_languages = get_i18n_field_param(Person, i18n_field, "required_languages")
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             check_languages(required_languages, Person)
 
@@ -62,7 +58,5 @@ class DefaultLanguageConfTest(TestCase):
     )
     def test_default_language_code_is_available_language(self):
         i18n_field = get_i18n_field(Person)
-        required_languages = get_i18n_field_param(
-            Person, i18n_field, "required_languages"
-        )
+        required_languages = get_i18n_field_param(Person, i18n_field, "required_languages")
         check_languages(required_languages, Person)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2,6 +2,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 
 from modeltrans.conf import check_fallback_chain, get_available_languages_setting
+from modeltrans.translator import check_languages, get_i18n_field, get_i18n_field_param
+
+from .app.models import Person
 
 
 class FallbackConfTest(TestCase):
@@ -37,3 +40,29 @@ class FallbackConfTest(TestCase):
         message = "MODELTRANS_AVAILABLE_LANGUAGES should be an iterable of strings"
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             get_available_languages_setting()
+
+
+class DefaultLanguageConfTest(TestCase):
+    @override_settings(
+        LANGUAGE_CODE="es", MODELTRANS_AVAILABLE_LANGUAGES=("nl", "de", "fr")
+    )
+    def test_django_language_code_not_available_language(self):
+        message = 'Language "en" is in required_languages on Model "Person" but not in settings.MODELTRANS_AVAILABLE_LANGUAGES.'
+        i18n_field = get_i18n_field(Person)
+        required_languages = get_i18n_field_param(
+            Person, i18n_field, "required_languages"
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, message):
+            check_languages(required_languages, Person)
+
+    @override_settings(
+        LANGUAGE_CODE="es",
+        MODELTRANS_DEFAULT_LANGUAGE="en",
+        MODELTRANS_AVAILABLE_LANGUAGES=("nl", "de", "fr"),
+    )
+    def test_default_language_code_is_available_language(self):
+        i18n_field = get_i18n_field(Person)
+        required_languages = get_i18n_field_param(
+            Person, i18n_field, "required_languages"
+        )
+        check_languages(required_languages, Person)


### PR DESCRIPTION
See use case in #116.

I worked with the existing test suite using the following patch and verified that everything still passed as expected:

```diff
diff --git a/tests/app/settings.py b/tests/app/settings.py
index a0adb93..5229cd3 100644
--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -90,8 +90,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = "en"
-
+LANGUAGE_CODE = "en-US"
+MODELTRANS_DEFAULT_LANGUAGE = "en"
 MODELTRANS_AVAILABLE_LANGUAGES = ("nl", "de", "fr")
 
 TIME_ZONE = "UTC"
```

I also added `DefaultLanguageConfTest` to verify that settings override got picked up.

Please let me know if there are any additional tests / documentation that would be required.