### PR TITLE
Add FileField support

### DIFF
--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -112,8 +112,9 @@ class TranslatedVirtualField:
         value = instance.i18n.get(field_name)
 
         if isinstance(self.original_field, fields.files.FileField):
-            # TODO: Review this versus `descriptor_class`; need to write some additional tests to verify
-            return self.attr_class(instance, self, value)
+            descriptor = self.descriptor_class(self)
+            descriptor.__set__(instance, value)
+            return descriptor.__get__(instance)
 
         return value
 

--- a/modeltrans/fields.py
+++ b/modeltrans/fields.py
@@ -13,7 +13,7 @@ from .utils import (
     get_translated_field_label,
 )
 
-SUPPORTED_FIELDS = (fields.CharField, fields.TextField, JSONField)
+SUPPORTED_FIELDS = (fields.CharField, fields.TextField, JSONField, fields.files.FileField)
 
 DEFAULT_LANGUAGE = get_default_language()
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -234,3 +234,18 @@ class Comment(models.Model):
 
     def __str__(self):
         return self.text
+
+
+class Attachment(models.Model):
+    post = models.ForeignKey(
+        Post,
+        on_delete=models.CASCADE,
+        limit_choices_to={"is_published": True},
+        related_name="attachments",
+    )
+    file = models.FileField()
+
+    i18n = TranslationField(fields=("file",))
+
+    def __str__(self):
+        return self.file.name

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -103,3 +103,12 @@ USE_L10N = True
 USE_TZ = True
 
 STATIC_URL = "/static/"
+
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.InMemoryStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -4,6 +4,7 @@ from unittest import skipIf
 import django
 from django.db import models
 from django.db.models import F, Q
+from django.db.models.functions import Collate
 from django.test import TestCase, override_settings
 from django.utils.translation import override
 
@@ -489,9 +490,9 @@ class OrderByTest(TestCase):
 
         filtered = Blog.objects.filter(category=c)
 
-        # order by title should result in aA because it is case sensitive.
-        qs = filtered.order_by("title", "title_nl")
-        self.assertEqual(key(qs, "title"), "a A")
+        # order by title should result in Aa because it is case sensitive.
+        qs = filtered.order_by(Collate("title", "C"), Collate("title_nl", "C"))
+        self.assertEqual(key(qs, "title"), "A a")
 
         # order by Lower('title') should result in Aa because lower('A') == lower('A')
         # so the title_nl field should determine the sorting

--- a/tests/test_translating.py
+++ b/tests/test_translating.py
@@ -45,6 +45,7 @@ class Translating_utils(TestCase):
             app_models.Challenge,
             app_models.ChallengeContent,
             app_models.Post,
+            app_models.Attachment,
             app_models.Comment,
         }
         self.assertEqual(set(get_translated_models("app")), expected)


### PR DESCRIPTION
Refs #118, #119

After implementing #119, I took a stab at `FileField` support.

I knew that `FileField` only stores a string in the database, but I didn't fully understand how the `FieldFile` wrapper was implemented for manipulating the field value.

The approach I've taken here is to mimic how the Django ORM typically interacts with `FileField` instances.

I've configured the tests to use [the InMemoryStorage class](https://docs.djangoproject.com/en/5.0/ref/files/storage/#the-inmemorystorage-class) to avoid needing to clean up temp files generated during tests.