### PR TITLE
Bump actions/setup-python from 5.1.0 to 5.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
         with:
           python-version: "3.11"
       - uses: actions/checkout@v4
@@ -14,7 +14,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
         with:
           python-version: "3.11"
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
   isort:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
         with:
           python-version: "3.11"
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
       - uses: actions/checkout@v4
       - run: python -m pip install -r docs/requirements.txt
       - run: cd docs/ && make html && make spelling
@@ -88,7 +88,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.1.1
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/checkout@v4

--- a/tests/test_translating.py
+++ b/tests/test_translating.py
@@ -1,3 +1,4 @@
+import django
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.test import TestCase
@@ -289,9 +290,12 @@ class TranslateModelTest(TestCase):
         comment = app_models.Comment.objects.create(post=published_post, text="foo")
         self.assertIsNotNone(comment.pk)
 
-        with self.assertRaisesMessage(
-            ValidationError,
-            f"post instance with id {unpublished_post.pk} does not exist",
-        ):
+        print(django.get_version())
+        if django.get_version().startswith("5.2"):
+            expected = f"post instance with id {unpublished_post.pk} is not a valid choice."
+        else:
+            expected = f"post instance with id {unpublished_post.pk} does not exist"
+
+        with self.assertRaisesMessage(ValidationError, expected):
             comment.post = unpublished_post
             comment.full_clean()

--- a/tests/test_translating.py
+++ b/tests/test_translating.py
@@ -290,7 +290,6 @@ class TranslateModelTest(TestCase):
         comment = app_models.Comment.objects.create(post=published_post, text="foo")
         self.assertIsNotNone(comment.pk)
 
-        print(django.get_version())
         if django.get_version().startswith("5.2"):
             expected = f"post instance with id {unpublished_post.pk} is not a valid choice."
         else:


### PR DESCRIPTION
Replacing #125

Also add a shim to a new expected value for form errors with limit_choices_to:

https://github.com/django/django/commit/31837dbcb36f1ab57fb1b16cb0b126c55a1bdf01