### PR TITLE
Support Django 6.0 and PostgreSQL 14, 15, 16, 17, 18, drop Python 3.9 support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: ["3.10", 3.11, 3.12, 3.13]
         django-version: [4.2, 5.1, 5.2, 6.0a1, "main"]
         postgres-version: ["postgres:14", "postgres:15", "postgres:16", "postgres:17", "postgres:18"]
         exclude:
@@ -52,25 +52,13 @@ jobs:
             - python-version: 3.13
               django-version: 4.2
 
-            # Django 5.1
-            - django-version: 5.1
-              python-version: 3.9
-
-            # Django 5.2
-            - django-version: 5.2
-              python-version: 3.9
-
             # Django 6.0
-            - django-version: 6.0a1
-              python-version: 3.9
             - django-version: 6.0a1
               python-version: "3.10"
             - django-version: 6.0a1
               python-version: 3.11
 
             # Django main
-            - django-version: main
-              python-version: 3.9
             - django-version: main
               python-version: "3.10"
             - django-version: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,36 +45,39 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
-        django-version: [4.2, 5.1, 5.2, "main"]
-        postgres-version: ["postgres:13.13", "postgres:14"]
+        django-version: [4.2, 5.1, 5.2, 6.0a1, "main"]
+        postgres-version: ["postgres:14", "postgres:15", "postgres:16", "postgres:17", "postgres:18"]
         exclude:
             # Django 4.2
-            - django-version: 4.2
-              python-version: 3.13
-            - django-version: 4.2
-              postgres-version: postgres:13.13
+            - python-version: 3.13
+              django-version: 4.2
 
             # Django 5.1
-            - python-version: 3.9
-              django-version: 5.1
             - django-version: 5.1
-              postgres-version: postgres:13.13
+              python-version: 3.9
 
             # Django 5.2
-            - python-version: 3.9
-              django-version: 5.2
             - django-version: 5.2
-              postgres-version: postgres:13.13
+              python-version: 3.9
 
-            # Django main (6.0)
-            - python-version: 3.9
-              django-version: main
-            - python-version: "3.10"
-              django-version: main
-            - python-version: 3.11
-              django-version: main
+            # Django 6.0
+            - django-version: 6.0a1
+              python-version: 3.9
+            - django-version: 6.0a1
+              python-version: "3.10"
+            - django-version: 6.0a1
+              python-version: 3.11
+
+            # Django main
             - django-version: main
-              postgres-version: postgres:13.13
+              python-version: 3.9
+            - django-version: main
+              python-version: "3.10"
+            - django-version: main
+              python-version: 3.11
+            - django-version: main
+              postgres-version: "postgres:14"
+
     services:
       postgres:
         image: ${{ matrix.postgres-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@ django-modeltrans change log
 
 ## In development
 - Support Python 3.9, 3.10, 3.11, 3.12, 3.13 and Django 4.2, 5.1, 5.2 and main (#129).
+- Support Django 6.0 and PostgreSQL 14, 15, 16, 17, 18 (#132)
 
 ## 0.8.0 (2024-07-02)
 - Add `JSONField` support (#119) refs: #118 by @jacobwegner
 - Add `MODELTRANS_DEFAULT_LANGUAGE` setting (#117) by @jacobwegner
-- Fix OperationalError under Django 5+ (#121) by @julianwachholz
+- Fix `OperationalError` under Django 5+ (#121) by @julianwachholz
 - Test using PostgreSQL 14 for django master (#122)
 - Drop Django 3.2 and 4.1 from the build matrix, add support for Django 5.0 and Django master, python 3.12 (#112, #105)
-- Fix blank fields trying to insert NULL (#110) by @julianwachholz
+- Fix blank fields trying to insert `NULL` (#110) by @julianwachholz
 - Fix translated form labels using current language (#108) by @julianwachholz
 - Update Django versions and CI link in README and documentation, remove import shims (#95) by @browniebroke
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ django-modeltrans change log
 
 ## In development
 - Support Python 3.9, 3.10, 3.11, 3.12, 3.13 and Django 4.2, 5.1, 5.2 and main (#129).
-- Support Django 6.0 and PostgreSQL 14, 15, 16, 17, 18 (#132)
+- Support Django 6.0 and PostgreSQL 14, 15, 16, 17, 18, drop Python 3.9 support (#132)
 
 ## 0.8.0 (2024-07-02)
 - Add `JSONField` support (#119) refs: #118 by @jacobwegner

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.0.*
+Django==5.2.*
 psycopg
 pytz==2021.1
 wheel==0.38.1

--- a/modeltrans/utils.py
+++ b/modeltrans/utils.py
@@ -103,10 +103,10 @@ class FallbackTransform(Transform):
 
     def as_postgresql(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        params.extend([self.field_prefix])
+        params = tuple(params) + (self.field_prefix,)
 
         rhs = self.language_expression.resolve_expression(compiler.query)
         rhs_sql, rhs_params = compiler.compile(rhs)
-        params.extend(rhs_params)
+        params = params + tuple(rhs_params)
 
         return ("({} ->> (%s || {} ))".format(lhs, rhs_sql), params)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 [tox]
 args_are_paths = false
 envlist =
-    py39-{4.2},
     py310-{4.2,5.1,5.2},
     py311-{4.2,5.1,5.2},
     py312-{4.2,5.1,5.2,main},
@@ -15,7 +14,6 @@ envlist =
 
 [testenv]
 basepython =
-    py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12


### PR DESCRIPTION
- Add Django 6.0 (https://docs.djangoproject.com/en/dev/releases/6.0/) to the build matrix
- Add Postgres 15, 16, 17 to the build matrix
- Remove Postgres 13 from the build matrix
- Upgrade required python version to fix dependabot warnings about insecure django version